### PR TITLE
chore: add SpecDD Starter Kit

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,161 @@
+# Frequently Asked Questions
+
+---
+
+## About SpecDD
+
+### Q: How is SpecDD different from just writing good prompts?
+A: A well-crafted one-off prompt is ad-hoc. SpecDD is a **structured process** with multiple gates, living artifacts, and explicit traceability between requirements and implementation. The spec exists as a persistent artifact that the AI references across sessions — not just a prompt you type once and discard.
+
+### Q: Do I need to write the spec myself or does the AI?
+A: The AI **generates** the spec based on your high-level input — but you **review and approve** it before it drives anything. Your role is to steer and verify; the AI does the drafting. The quality of your input to `/sdd-specify` directly determines the quality of the spec.
+
+### Q: Is SpecDD just for big features? Isn't it overkill for small changes?
+A: Yes — calibrate to size. For small, isolated bug fixes, a spec is overkill. For anything that touches multiple components, introduces new patterns, or will be maintained over time, the spec investment pays back quickly. See [greenfield-guide.md](../instructions/spec-generation/greenfield-guide.md) for sizing guidance.
+
+### Q: Is SpecDD appropriate for all types of development work?
+A: Not equally. SpecDD works best for **end-to-end or standalone feature builds** — especially in brownfield contexts with existing architecture constraints. It is less effective for:
+- Scattered refactors across unrelated modules
+- Incremental edits or narrow fixes that touch only 1–2 files
+- Routine technical maintenance (code cleanups, deprecating old APIs)
+
+For those cases, local AI tools (Copilot inline, Cursor edits) are faster and more precise. Reserve SpecDD for medium-to-large features where design structure, system integration, and context propagation matter.
+
+### Q: Can I use SpecDD with an existing codebase?
+A: Absolutely — it's actually where SpecDD delivers the most value, by giving the AI enough context to not inadvertently break existing patterns. See [brownfield-guide.md](../instructions/spec-generation/brownfield-guide.md) for the recommended approach.
+
+### Q: Which teams benefit most from SpecDD?
+A: Based on EPAM's production deployments, SpecDD delivers the highest ROI for:
+
+| Team Type | Why SpecDD Helps |
+|---|---|
+| Teams using AI-native tooling (Copilot, Cursor, Claude Code) | Structured specs give agents reliable, non-hallucinated output |
+| Leads/architects hitting the ceiling of agentic development | SpecDD provides context alignment and multi-service coordination |
+| Enterprise/brownfield projects | Legacy constraints and compliance requirements need explicit encoding |
+| Multi-service engineering orgs | Mismatched assumptions across services create rework; specs prevent this |
+| Platform teams building shared services | Clear contracts, versioning discipline, and predictable integration patterns |
+
+Teams doing purely isolated fixes, simple scripts, or single-file tools see less benefit.
+
+---
+
+## Setup & Tooling
+
+### Q: Do I need the GitHub Spec Kit CLI?
+A: No. This starter kit is self-contained — it provides all the prompt files, templates, and structure you need. The GitHub Spec Kit CLI (`specify`) is optional and provides additional automation. If you want to use it, see [SETUP.md](../SETUP.md#option-b--github-spec-kit-cli).
+
+### Q: Which AI agents are supported?
+A: GitHub Copilot is the primary target for this kit (using `.github/prompts/*.prompt.md` slash commands). The prompts work equally well with Claude Code (using `CLAUDE.md`), Cursor, Gemini CLI, and most other code-capable agents. See [README.md](../README.md#supported-ai-agents) for setup per agent.
+
+### Q: How do I set this up for a team?
+A: The entire kit is version-controlled. All team members use the same prompt files, Context, and spec templates from the repo. The `.github/copilot-instructions.md` is automatically applied to all Copilot sessions in the workspace.
+
+### Q: Which AI model should we use for SpecDD?
+A: Model intelligence directly affects output quality — and this is a **productivity decision, not just a cost choice**. More capable models (e.g., Claude Sonnet 4.5 vs. 4.0) hold context across longer implementations, detect existing code for reuse more reliably, follow constitution rules more consistently, and make stronger architectural choices. In EPAM's enterprise production deployment, upgrading from Claude Sonnet 4.0 to 4.5 cut rework time nearly in half. The economics: a more capable model costs more per token but saves exponentially more engineering hours. Using cheaper or older models often means spending the difference fixing and refactoring their output.
+
+---
+
+## Spec Writing
+
+### Q: How detailed should the spec be?
+A: Detailed enough that two developers would independently implement it the same way, but no more. The spec defines **what** and **why**. The plan defines **how**. Avoid specking implementation details (those belong in `plan.md`). A spec with 3–7 user stories and GIVEN/WHEN/THEN acceptance criteria is usually the right size.
+
+### Q: What if requirements change mid-implementation?
+A: Update `spec.md` first — it's the source of truth. Then update `plan.md` if the technical approach changes. Then update `tasks.md` to reflect changed/added tasks. Never implement requirements that aren't in the spec.
+
+### Q: The AI generated a spec that misses my intent. What do I do?
+A: Don't proceed to planning with a bad spec. Either:
+1. Revise your input prompt and re-run `/sdd-specify` with more specific guidance
+2. Edit `spec.md` directly, then commit the revised version
+3. Use `/sdd-clarify` to surface and resolve the gaps
+
+---
+
+## Implementation
+
+### Q: Can I run all tasks at once instead of one at a time?
+A: You can, but it's not recommended for most cases. Task-by-task execution lets you catch issues early before they compound. For a small feature with simple, independent tasks, the AI can execute multiple tasks safely. For anything complex or interrelated, sequential execution with verification is much safer.
+
+### Q: What if the AI modifies existing code I didn't want it to touch?
+A: Add explicit "do not modify" constraints to your prompt, or add them to `agent-boundaries.md`. Then re-run the task. For brownfield projects, the research phase should identify which existing files must not be changed.
+
+### Q: How do I handle a task that turns out to be much larger than expected?
+A: Split it. Update `tasks.md` to replace the oversized task with 2–4 smaller sub-tasks. This is a normal part of the process — early task estimates often reveal complexity only when you start implementing.
+
+### Q: How much time does it take to write a good constitution?
+A: Writing an effective constitution is **not an entry-level task**. Expect 2–3 days of initial effort from senior engineers who understand the system's structure, team working patterns, and the reasoning behind architectural choices. Before generating the constitution, clean up any outdated `.md` files in your repo — the AI heavily weights these when drafting. Plan to continue refining the constitution through real-world use; most early revisions involve removing generated code that violated unstated rules. A constitution is a living document — it evolves as the system does and becomes more valuable over time.
+
+### Q: Should I expect to keep all the AI-generated code?
+A: No — and **60–80% retention after review is an excellent result**. Expect 20–40% of generated code to need adjustment for missed edge cases, integration issues, over-engineered patterns, or constitution violations. Code quality also varies unpredictably within a single feature — some outputs are production-ready, others have subtle issues. Treat AI output like a capable junior developer's PR: review carefully, correct where needed, and accept that human judgment remains essential.
+
+---
+
+## Quality & Review
+
+### Q: How do I verify the AI actually satisfied an acceptance criterion?
+A: Each task in `tasks.md` should have an explicit **acceptance test** — a command to run or a manual check to perform. After implementation, run it. If it passes, the criterion is satisfied. If not, the task isn't done yet.
+
+### Q: Should I review every line of AI-generated code?
+A: You should review all code before merging, but your focus should be on:
+1. Does it satisfy the spec?
+2. Does it follow the plan's technical design?
+3. Does it pass the quality checklist?
+You don't need to re-read obvious boilerplate line-by-line — focus your review on the critical logic.
+
+### Q: The AI keeps violating the same rule. How do I fix this?
+A: Add the rule explicitly to:
+1. `context/constitution.md` (Section 7 — AI Agent Rules)
+2. `.github/copilot-instructions.md` (or your agent's config)
+3. `instructions/code-generation/agent-boundaries.md`
+The more specific and prominent the rule, the more consistently it will be followed.
+
+### Q: Reviewing AI-generated markdown is exhausting. Is that normal?
+A: Yes — this is a real, widely-reported, and under-discussed cost of AI-assisted development. AI-generated specs and plans are grammatically correct and architecturally plausible, which makes them harder to review than code: there's no compiler to catch conceptual errors. Validating plausible-sounding text for factual and architectural accuracy requires sustained concentration that depletes faster than most teams expect.
+
+Mitigations that help:
+- Use structured review checklists to anchor attention (see [spec-quality-checklist.md](../instructions/spec-generation/spec-quality-checklist.md))
+- Rotate who reviews which artifacts across team members
+- Take short breaks between reviewing different artifact types (spec vs. plan vs. tasks)
+- Treat it like code review — not casual reading
+
+The cognitive load doesn't disappear with SpecDD — it shifts from *writing* to *verifying*. The net benefit is still strongly positive, but teams that underestimate review burden often abandon the process before reaping the gains.
+
+---
+
+## Enterprise & Team Adoption
+
+### Q: What is "SpecFall" and how do we avoid it?
+A: SpecFall is the SpecDD equivalent of Scrumerfall — installing spec-driven ceremonies without changing how people actually work together. Symptoms: specs are created but ignored in practice, product managers don't own the "What" phase, architects aren't involved in the "How" phase, specs become stale markdown that nobody reviews.
+
+Avoid it by treating SpecDD as an **organizational capability**, not just a technical practice:
+- Product team owns and approves `spec.md` (the What)
+- Architects own and approve `plan.md` (the How)
+- Engineers own and approve `tasks.md` (the execution)
+- QA transitions from validating implementations to validating harness quality
+
+### Q: Our feature spans multiple repositories. Where does the spec live?
+A: Use architectural decomposition:
+1. Create a **parent-level spec** in a shared location (or the primary repo) covering business intent, affected repositories, and integration contracts
+2. Create **per-repo specs** scoped to that repository's responsibilities
+3. Business context lives in the backlog (Jira / ADO); technical sub-tasks live in their respective repos
+
+See [brownfield-guide.md](../instructions/spec-generation/brownfield-guide.md#multi-repository-brownfield-features) for the full pattern.
+
+### Q: The AI-generated code had a bug. Was that a spec problem or a code problem?
+A: Ask two questions:
+1. **Was the correct behavior described in the spec?** If no — it's an Intent-to-Spec gap. Update the spec/constitution so future features capture this intent automatically.
+2. **Was the spec correct but the AI diverged?** If yes — it's a Spec-to-Implementation gap. Strengthen task detail, add explicit implementation constraints, or add to `agent-boundaries.md`.
+
+In mature SpecDD, bugs become **harness improvement opportunities** rather than just one-off code fixes.
+
+### Q: How does SpecDD change the role of QA/testers?
+A: QA transitions from "validate finished implementations" to **"validate the context harnesses that shape agent behavior"**:
+- Review spec quality: are the acceptance criteria testable and complete?
+- Validate that tasks correctly trace back to spec requirements
+- Identify harness gaps when bugs surface (was intent captured correctly?)
+- Build automated spec-to-implementation alignment checks
+
+This is more leverage: improving the harness prevents entire classes of future bugs, rather than catching individual defects after the fact.
+
+### Q: Is every change — even small bug fixes — supposed to go through SpecDD?
+A: In early adoption: no, calibrate to size. In mature SpecDD adoption: ideally yes, because specs are the primary interface for directing AI agent execution. Directly patching code without updating the spec widens the gap, and the defect can resurface in different forms when the AI regenerates code from the unchanged spec. The goal is to make it easy to "do the right thing" at the spec level.

--- a/docs/greenfield-vs-brownfield.md
+++ b/docs/greenfield-vs-brownfield.md
@@ -1,0 +1,192 @@
+# Greenfield vs. Brownfield SpecDD
+
+> Practical comparison of SpecDD adoption for new projects versus existing codebases.
+
+---
+
+## At a Glance
+
+| Dimension | Greenfield (New Project) | Brownfield (Existing Codebase) |
+|---|---|---|
+| **Entry point** | Phase 0 — Context | Research phase → Partial Context |
+| **First task** | Define constitution from scratch | Reverse-engineer existing patterns |
+| **Context source** | You define it | Codebase defines it |
+| **Risk** | Scope creep, over-engineering | Regressions, invisible constraints |
+| **First spec** | Core feature or foundation | Narrow, isolated capability |
+| **Context effort** | High (creating from scratch) | Medium (extracting from existing code) |
+| **Constitution** | Written aspirationally | Written descriptively (then aspirationally) |
+| **Agent risk** | AI invents inappropriate patterns | AI ignores established patterns |
+
+---
+
+## Greenfield: When & How
+
+### When to Use Greenfield Approach
+- Starting a net-new project
+- Creating a new service / microservice
+- Building a new module with no shared state
+
+### Recommended Sequence
+
+```
+1. Phase 0: Context (full setup)
+   /sdd-constitution → context/constitution.md
+   Fill in project.md, architecture.md, tech-stack.md
+
+2. Phase 1: Core Domain Spec
+   /sdd-specify → specs/001-[domain-core]/spec.md
+
+3. Phase 2: Plan
+   /sdd-plan → specs/001-[domain-core]/plan.md
+
+4. Phase 3–4: Tasks + Implementation
+   /sdd-tasks + /sdd-implement
+   Establish patterns and structural decisions
+
+5. Subsequent features
+   Add specs sequentially, referencing established patterns
+```
+
+### Greenfield Tips
+- Set the constitution **before** writing any code — it constrains all future decisions
+- Spec the foundation first (data model, authentication, deployment) — it anchors everything else
+- Resist over-speccing: define what you're building now, not future aspirations
+- Use the constitution to explicitly ban patterns you want to avoid
+
+---
+
+## Brownfield: When & How
+
+### When to Use Brownfield Approach
+- Adding features to an existing application
+- Onboarding AI development to an established codebase
+- Teams new to SpecDD who already have a working product
+
+### Recommended Sequence
+
+```
+1. Research Phase (before any SpecDD prompts)
+   Read key files: README, main config, core models, existing tests
+   Fill in specs/_template/research.md with discovered patterns
+   Document: patterns in use, patterns to avoid, forbidden files
+
+2. Extract to Context
+   /sdd-constitution → draft from existing codebase
+   Describe what exists (not what you'd like)
+   Add explicit "do not modify" constraints
+
+3. Start with a Narrow Spec
+   Choose a feature that:
+   - Touches as few existing files as possible
+   - Has clear entry and exit points
+   - Is non-critical (lower risk for first SpecDD feature)
+
+4. Research-Informed Planning
+   Attach research.md to /sdd-plan prompt
+   Call out integration constraints explicitly
+
+5. Expand Incrementally
+   Each new spec builds on the established Context
+   Update architecture.md as you learn more about the system
+```
+
+### Brownfield Tips
+- **Research first, always.** Never let the AI guess at existing patterns — it will invent its own
+- Explicitly list files the AI must not modify in `agent-boundaries.md`
+- Your first spec's primary value is establishing trust in the process, not the feature itself
+- Add your current patterns to `tech-stack.md` even if they're not ideal — the AI will follow them
+- Use `research.md` to capture reverse-engineered context for each new area of the codebase
+
+### Reverse-Engineering Existing Code into a Spec
+For existing functionality you want to document retroactively:
+
+```
+1. Collect: Read the relevant source files, tests, migration files
+2. Prompt: "Based on [attached files], write a spec in our spec format for [existing feature]"
+3. Review: Verify the generated spec against actual behavior
+4. Commit: Add spec.md and plan.md with status "Implemented"
+5. Benefit: Future changes to this feature now have a spec anchor
+```
+
+---
+
+## Adoption Strategies
+
+| Strategy | Description | Best For |
+|---|---|---|
+| **Feature-first** | Add SpecDD for the next new feature | Teams wanting minimal disruption |
+| **Parallel track** | Run SpecDD alongside existing process; compare output quality | Teams evaluating SpecDD before committing |
+| **Foundation layer** | Start with Context and constitution; add specs feature-by-feature | Teams serious about long-term adoption |
+| **Retro-spec a module** | Document existing high-churn areas with specs | Teams trying to stabilize unstable areas |
+
+---
+
+## Common Pitfalls by Approach
+
+### Greenfield Pitfalls
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| No constitution | AI makes inconsistent pattern choices | Write constitution before first feature spec |
+| Over-speccing | Specs block progress; describe future, not present | Keep spec focused on current iteration |
+| Skipping research.md | Third-party integration assumptions | Always create research.md for external dependencies |
+
+### Brownfield Pitfalls
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| Skipping research | AI rewrites existing patterns differently | Research phase is mandatory, not optional |
+| Too-broad first spec | First feature touches half the codebase | Start with smallest possible isolated feature |
+| Constitution over-prescription | Constitution describes ideal, not reality | First draft: describe what IS, then what SHOULD BE |
+| Invisible constraints | AI modifies files it shouldn't | Explicit "do not modify" lists in agent-boundaries.md |
+
+---
+
+## The "SpecFall" Risk
+
+> **SpecFall** = installing spec-driven ceremonies without changing how teams actually collaborate. The SpecDD equivalent of Scrumerfall.
+
+Signs you're heading toward SpecFall:
+- Specs are written by one developer in isolation, without product or architecture input
+- `spec.md` describes implementation steps rather than user intent
+- Specs are created at project start and never updated
+- Review gates exist on paper but are rubber-stamped
+- Product managers and architects never interact with spec artifacts
+
+### How to Avoid It
+
+| Practice | Greenfield | Brownfield |
+|---|---|---|
+| **Who owns spec.md** | Product / BA with engineer collaboration | Same — frame as "feature intent doc" not "dev doc" |
+| **Who owns plan.md** | Architect / Tech Lead | Same — critical for avoiding legacy pitfalls |
+| **When to update spec** | On any requirement change | On any behavior change, even bug fixes |
+| **Spec review gate** | Cross-functional (product + arch + dev) | Same |
+| **Success metric** | Spec reduces rework, not just documents it | Same + spec reduces legacy breakage |
+
+---
+
+## Enterprise Separation of Concerns
+
+At enterprise scale, specs must be organized by **audience and evolution pace**:
+
+| Artifact Type | Audience | Evolution Pace | Location |
+|---|---|---|---|
+| Business intent / user stories | Product, BA, stakeholders | Slow (feature-scoped) | `spec.md` |
+| Acceptance criteria | Product, QA | Slow | `spec.md` |
+| Architecture decisions | Architects, Tech Leads | Medium (feature + cross-cutting) | `plan.md`, `context/architecture.md` |
+| Data model / API contracts | Engineers, Architects | Medium–Fast | `data-model.md`, `contracts/` |
+| Tasks / implementation steps | Engineers | Fast (highly tactical) | `tasks.md` |
+| Project-wide rules | All AI agents | Very slow | `context/constitution.md` |
+
+> Mixing all artifact types in a single file (as some SpecDD tools do) creates friction for cross-functional collaboration. The starter kit's separation reflects this concern.
+
+---
+
+## Infrastructure Considerations
+
+SpecDD works well for application code (greenfield or brownfield) but requires adaptation for infrastructure code (Terraform, Helm, etc.):
+
+- **Infrastructure teams often work backward from drift** (actual state → desired spec), not forward from spec → code
+- Use **blueprints** rather than one-off specs: standardized, versioned infrastructure patterns that can be deployed across environments
+- Spec the **intent** (e.g., "regional infrastructure with standard security controls") and generate from a blueprint catalog, not raw Terraform
+- Drift detection tooling (e.g., cloud graph reconciliation) is especially critical for IaC SpecDD
+
+This is distinct from application SpecDD and typically requires separate tooling (e.g., environment orchestrators).

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,84 @@
+# References & Resources
+
+Curated reading list for Spec-Driven Development.
+
+---
+
+## Foundational Reading
+
+| Title | Link | Why Read It |
+|---|---|---|
+| Spec-Driven Development — InfoQ (Intro) | https://www.infoq.com/articles/spec-driven-development/ | Architectural framing: the 5-layer SpecDD model (Specification → Generation → Artifact → Validation → Runtime), SpecOps concept, drift detection as mandatory capability, architectural inversion |
+| Enterprise Spec-Driven Development — InfoQ | https://www.infoq.com/articles/enterprise-spec-driven-development/ | Enterprise adoption: Vibe Coding → Plan Mode → SpecDD evolution arc, "SpecFall" anti-pattern, multi-repo orchestration, harness governance, brownfield incremental pattern, cross-functional ownership model |
+| EPAM — What GitHub Spec Kit Makes Possible | https://www.epam.com/insights/ai/blogs/spec-driven-development-ai-assisted-engineering | ✅ Conceptual foundation article (Oct 2025). Four structural AI limits (scope/duration, feature context, project knowledge, uncontrolled autonomy); 1–3 files = high quality, 10+ files = coherence breaks (scope > duration rule); six-stage workflow; constitution as project DNA (stack, naming, architectural rationale, library governance, compliance); layered context system; five team types that benefit most; scope fit limitation (scattered refactors = poor fit); developer role evolution; safe delegation window concept |
+| Martin Fowler — SpecDD Tools (Kiro, spec-kit, Tessl) | https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html | Critical analysis of SpecDD levels and tools |
+| O'Reilly — How to Write a Good Spec for AI Agents | https://www.oreilly.com/radar/how-to-write-a-good-spec-for-ai-agents/ | Practical spec writing framework (5 principles) |
+| The New Stack — Is SpecDD Key for Infrastructure Automation | https://thenewstack.io/is-spec-driven-development-key-for-infrastructure-automation/ | Infrastructure perspective: why IaC needs blueprint-driven (not spec-driven) approach; infra teams work backward from drift |
+
+---
+
+## Official Tooling
+
+| Resource | Link | Notes |
+|---|---|---|
+| GitHub Spec Kit | https://github.com/github/spec-kit | Official open-source toolkit (CLI + templates) |
+| GitHub Blog — SpecDD with AI | https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/ | Getting started guide from GitHub |
+| Spec Kit Documentation | https://github.github.io/spec-kit/ | Full docs for `specify` CLI |
+| Kiro (Amazon) | https://kiro.dev/ | VS Code-based SpecDD tool (Requirements → Design → Tasks) |
+| Tessl Framework | https://docs.tessl.io/introduction-to-tessl/quick-start-guide-tessl-framework | Spec-as-source SpecDD (private beta) |
+
+---
+
+## Brownfield / Reverse Engineering
+
+| Resource | Link | Purpose |
+|---|---|---|
+| Firecrawl | https://www.firecrawl.dev/ | Generate specs from existing systems / documentation |
+| Microsoft Learn — Implement SpecDD with Spec Kit | https://learn.microsoft.com/training/modules/implement-spec-driven-development-using-github-spec-kit/ | Step-by-step hands-on training module |
+| EPAM — Using Spec Kit for Brownfield | https://www.epam.com/insights/ai/blogs/using-spec-kit-for-brownfield-codebase | ✅ Full production retrospective from EPAM's AI/Run team on a 280k-line, 10-developer codebase. Key insights: constitution crafting takes 2–3 days (senior engineers); the four-pillar constitution model (reuse policy, project architecture, forbidden patterns, accurate terminology); feature sizing (1–5 day scope, ~40–50 requirements per spec); cumulative quality degradation math (0.8^5 ≈ 0.33 without review gates); phase-checkpoint execution loop; AI deviation patterns; 60–80% code retention is excellent; model quality as productivity decision (Sonnet 4.5 vs 4.0 halved rework); "third refinement rule"; prompt-based vs manual refinements; review fatigue as an operational reality |
+
+---
+
+## Practitioner Guides
+
+| Resource | Link | Notes |
+|---|---|---|
+| AugmentCode — Mastering SpecDD | https://www.augmentcode.com/guides/mastering-spec-driven-development-with-prompted-ai-workflows-a-step-by-step-implementation-guide | ✅ Structured specification framework; complete 5-part prompt template (Context + Specification + Requirements + Expected Output + Constraints); confidence-based quality gates (High >90% / Medium 70-90% / Low <70%); 8-week phased team adoption timeline; 19% research finding (AI can increase completion time without structure); MetaGPT-style task decomposition; treat SpecDD as evolution of software engineering practice, not replacement |
+| Intuition Labs — Spec Kit Guide | https://intuitionlabs.ai/articles/spec-driven-development-spec-kit | Detailed walkthrough of 4 phases; "Every hour on planning saves 10 hours of rework"; role shift from code writer to architect/validator |
+| How to Write a Great agents.md | https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/ | Lessons from 2,500+ agent config files |
+
+---
+
+> **Access note:** Both EPAM articles were incorporated via user-provided content (epam.com returns 403 Forbidden to automated fetching). Microsoft Learn SpecDD module (`learn.microsoft.com/training/...`) appears to have been removed. YouTube walkthrough videos require authentication to access directly.
+
+---
+
+## Videos
+
+| Title | Link | Duration |
+|---|---|---|
+| Spec-Driven Development Overview | https://youtu.be/MGzymaYBiss | Overview |
+| Spec Creation — Greenfield | https://www.youtube.com/watch?v=a9eR1xsfvHg&t=1182s | Greenfield walkthrough |
+| Spec Creation — Brownfield | https://www.youtube.com/watch?v=SGHIQTsPzuY&t=547s | Brownfield walkthrough |
+
+---
+
+## Context Engineering (Advanced)
+
+| Resource | Link | Notes |
+|---|---|---|
+| Anthropic — Effective Context Engineering | https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents | Deep dive into context management |
+| Addy Osmani — Context Engineering | https://addyo.substack.com/p/context-engineering-bringing-engineering | Hierarchical summarization patterns |
+| Simon Willison — Vibe Engineering | https://simonwillison.net/2025/Oct/7/vibe-engineering/ | Practical AI coding craft |
+
+---
+
+## Related Methodologies
+
+| Methodology | Relationship to SpecDD |
+|---|---|
+| TDD (Test-Driven Development) | SpecDD borrows the "define success criteria first" principle |
+| BDD (Behavior-Driven Development) | GIVEN/WHEN/THEN ACs in SpecDD are inspired by BDD |
+| PRD (Product Requirements Document) | SpecDD spec is essentially a structured, executable PRD |
+| MDD (Model-Driven Development) | Historical precedent for spec-as-source — with lessons learned |
+| ADR (Architecture Decision Records) | Recommended for `context/architecture.md` |

--- a/docs/sdd-methodology.md
+++ b/docs/sdd-methodology.md
@@ -1,0 +1,294 @@
+# SpecDD Methodology
+
+> A concise reference guide to Spec-Driven Development concepts, phases, and principles.
+> For the full starter kit workflow, see README.md and SETUP.md.
+
+---
+
+## What is Spec-Driven Development?
+
+Spec-Driven Development (SpecDD) is a structured approach to AI-assisted software development where:
+
+> **Specifications are the source of truth. Code is the output.**
+
+Instead of prompting an AI to write code from a vague description, SpecDD maintains a set of **living specification artifacts** that define intent, architecture, and tasks — and uses these to drive the AI through implementation in a controlled, verifiable way.
+
+Key insight: AI coding agents excel at **pattern completion**, but struggle with **mind reading**. A vague prompt like "add photo sharing" forces the model to guess at thousands of unstated requirements. A specification makes intent explicit.
+
+---
+
+## Why AI-Assisted Development Needs Spec-Driven Development
+
+AI coding agents are powerful but carry well-documented structural constraints. Understanding these explains why structured specs — not cleverer prompts — are the correct solution.
+
+### 1. Task Scope & Duration Constraints
+
+LLMs deliver high-quality output on small, clearly scoped tasks. Quality degrades non-linearly as scope expands:
+
+| Change Scope | Expected Quality |
+|---|---|
+| 1–3 files | High quality, reliable output |
+| 4–9 files | Inconsistencies begin to emerge |
+| 10+ files | Coherence breaks down; extensive rework typical |
+
+> **Scope matters more than duration.** A 20-minute task touching 15 files will produce worse output than a 90-minute task touching 3 files. This is a fundamental LLM coherence constraint — not a prompting issue.
+
+SpecDD solves this via enforced decomposition: Feature → User Stories → Tasks, where each task is scoped to 1–2 files with bounded responsibility.
+
+### 2. Feature Context Gaps
+
+Even a codebase-aware assistant lacks context about the specific feature being built: requirements, edge cases, acceptance criteria, integration points, data flows. This dual gap — functional scope + system integration — produces features that either don't meet requirements or don't fit existing architecture.
+
+SpecDD solves this via a **two-layer context system**:
+- **Specification layer** (`spec.md`, refined by `/sdd-clarify`): the *what* — requirements, user stories, acceptance criteria, edge cases
+- **System design layer** (`plan.md`, `data-model.md`, `api.md`): the *how* — affected services, data flows, integration points
+
+Unlike prompts that disappear after execution, these artifacts create a persistent blueprint that prevents drift and enforces consistency across sessions.
+
+### 3. Project Knowledge Gaps
+
+AI assistants can scan a repository, but reading code is not the same as understanding its context. Every codebase has project-specific conventions, approved libraries, reusable components, and enterprise rules that LLMs cannot reliably infer — and they may reproduce outdated patterns from legacy files simply because those files exist.
+
+SpecDD solves this via the **constitution**: a persistent, project-specific intent layer encoding stack standards, naming rules, architectural rationale (including the *reasons* behind past decisions), library governance, forbidden patterns, and compliance requirements. The AI reads this before implementing anything — operating from YOUR standards, not generic best practices from training data.
+
+### 4. Uncontrolled Autonomy
+
+AI agents in autonomous mode produce bulk code dumps with no traceability. Changes span 10–15 files, introduce unplanned integrations, and make architecture-level choices without validation. No intermediate state is visible; identifying what went wrong requires tedious review of the entire output.
+
+SpecDD solves this via **mandatory review gates** at each phase — spec, plan, tasks, implementation checkpoints — structuring automation around human approval at the right depth without slowing execution elsewhere.
+
+> **Counter-intuitive research finding:** In rigorous controlled studies, AI tools *increased* completion time by 19% for experienced developers working without structured workflows. The output volume was higher; the useful, correct output was lower. Structure is not overhead — it is what makes AI assistance net-positive.
+
+---
+
+## The SpecDD Architecture: Five Layers
+
+SpecDD is not just a methodology — it is an **architectural pattern** that inverts the traditional source of truth. In classical software, code is authority; in SpecDD, the specification is.
+
+| Layer | Role | Example Artifacts |
+|---|---|---|
+| **Specification** | Authoritative declaration of what the system must do | `spec.md`, `api.md`, `data-model.md`, constraints |
+| **Generation** | Transforms declarative intent into executable form | AI agent generating code, tests, stubs from spec |
+| **Artifact** | Concrete outputs of generation — disposable, regenerable | Source code, generated models, migration files |
+| **Validation** | Continuous enforcement of alignment between spec and reality | Contract tests, schema validators, spec diff tools |
+| **Runtime** | The operating system, constrained entirely by upstream layers | Deployed services, APIs |
+
+> **Architectural inversion**: In SpecDD, code is not the source of truth — it is merely the current realization of truth. If the spec changes, code is regenerated. If code deviates from the spec, that is **drift** — a defect to be corrected, not a feature.
+
+### SpecOps: Specification Operations
+
+Just as DevOps elevated infrastructure to a first-class engineering discipline, **SpecOps** treats specification authoring as a first-class engineering surface:
+
+- Specs are version-controlled and peer-reviewed like production code
+- Spec quality directly determines implementation quality
+- Bugs are traced back to specification gaps, not just code defects
+- Two failure modes exist: **Intent-to-Spec gaps** (spec captures wrong/incomplete intent) and **Spec-to-Implementation gaps** (code diverges from spec)
+
+---
+
+## SpecDD Levels
+
+| Level | Human Role | Spec Lifecycle | When to Use |
+|---|---|---|---|
+| **Spec-First** | Write spec before coding | Spec created for the change, may be archived after | Quick features, experiments |
+| **Spec-Anchored** | Maintain spec as feature evolves | Spec is kept and updated alongside code | Team features, long-lived components |
+| **Spec-as-Source** | Human edits spec; AI regenerates code | Spec is the primary artifact; code is derived | Mature SpecDD, enterprise contexts |
+
+---
+
+## The SpecDD Workflow
+
+### Phase 0: Context
+Establish project-wide context that's always available to the AI agent.
+
+| Artifact | Purpose |
+|---|---|
+| `constitution.md` | Immutable governing principles |
+| `architecture.md` | System architecture and patterns |
+| `tech-stack.md` | Approved technologies and conventions |
+| `project.md` | Project context, users, success criteria |
+
+**Gate:** Context must be established before first spec is written.
+
+---
+
+### Phase 1: Specify
+Define **what** to build and **why** — purely functional, no technical detail.
+
+| Activity | Output |
+|---|---|
+| Describe feature to AI | `spec.md` with user stories, ACs, user journeys |
+| Human reviews spec | Gaps and ambiguities identified |
+| Optionally: run `/sdd-clarify` | Open questions resolved |
+
+**Gate:** No technical decisions. No implementation details. Human approves spec.
+
+---
+
+### Phase 2: Plan
+Translate the spec into **how** to build it — architecture, data models, APIs, components.
+
+| Activity | Output |
+|---|---|
+| Provide tech stack + constraints | `plan.md` with architecture decisions |
+| | `data-model.md` with schema changes |
+| | `api.md` with endpoint contracts |
+| Human reviews plan | Technical correctness verified |
+
+**Gate:** Plan must conform to constitution and tech-stack. Human approves plan.
+
+---
+
+### Phase 3: Tasks
+Break the plan into **atomic, independently testable implementation tasks**.
+
+| Activity | Output |
+|---|---|
+| AI generates task breakdown | `tasks.md` with ordered, traceable tasks |
+| Optionally: run `/sdd-analyze` | Traceability verified, gaps found |
+| Human reviews task list | Ordering, completeness confirmed |
+
+**Gate:** Every acceptance criterion must be traceable to at least one task. Human approves.
+
+---
+
+### Phase 4: Implement
+Execute tasks one by one with the AI agent, verifying each before proceeding.
+
+| Activity | Output |
+|---|---|
+| AI implements each task | Working code, tests, commits |
+| Human verifies per task | Spec compliance checked |
+| Run review checklist | Quality gate passed |
+
+**Gate:** All tasks complete, all ACs satisfied, quality checklist done.
+
+---
+
+## Key Concepts
+
+### Context vs. Spec
+| Context | Spec |
+|---|---|
+| Always in context | Only relevant during work on that feature |
+| Project-wide context | Feature-specific context |
+| Evolves slowly | Created per feature/change |
+| Constitution, architecture, tech stack | Spec, plan, tasks, data model, API |
+
+### Three-Tier Boundary Model for AI Agents
+Based on research from analysis of 2,500+ agent configuration files:
+
+| Tier | Meaning |
+|---|---|
+| ✅ Always Do | Safe actions; AI proceeds without asking |
+| ⚠️ Ask First | Actions requiring human approval |
+| 🚫 Never Do | Hard stops; AI must refuse or escalate |
+
+### Enterprise Collaboration Model
+
+At team and enterprise scale, different roles own different phases of the SpecDD workflow:
+
+| Phase | Owner | Artifact | AI Role |
+|---|---|---|---|
+| **Discover** (What) | Product / Business Analyst | `spec.md` requirements, user stories, ACs | Facilitates dialogue, fills in details |
+| **Design** (How) | Architect / Tech Lead | `plan.md`, `data-model.md`, `contracts/` | Generates technical approach from constraints |
+| **Tasks** | Developer / Engineer | `tasks.md` | Breaks design into atomic, verifiable work items |
+| **Implement** | Developer + AI Agent | Working code | Executes tasks one by one |
+
+This separation keeps business context visible on product boards while technical details live in the repository. For multi-repo features, the architect decomposes the feature into per-repo sub-tasks, each scoped to a single repository boundary.
+
+### Drift Detection
+
+Once specifications become authoritative, **drift detection** is a mandatory architectural capability:
+
+- A spec is not merely documentation — it is an **active control surface**
+- Drift = any divergence between declared intent and observed behavior (structural, behavioral, semantic, or security-related)
+- Mechanisms: contract tests, schema validators, spec diff tools, CI-embedded checks
+- Without drift detection, SpecDD collapses back into documentation-driven development
+
+### Spec as Living Artifact
+A spec is not written once and discarded. It:
+- Evolves as requirements change
+- Stays consistent with implementation via the plan
+- Serves as the reference for future changes and maintenance
+- Reduces onboarding time for new team members and AI agents
+
+---
+
+## SpecDD vs. Other Approaches
+
+| Dimension | Ad-hoc Prompting | TDD | SpecDD |
+|---|---|---|---|
+| Starting point | Vague description | Failing test | Functional specification |
+| Primary artifact | Code | Test suite | Specification |
+| AI role | Code generator | Test executor | Structured collaborator |
+| Traceability | None | Test → code | Requirement → task → code |
+| Context window management | Manual | N/A | Spec-as-context pattern |
+| Brownfield capability | Low | Medium | High (with research phase) |
+
+---
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Problem | Resolution |
+|---|---|---|
+| Vague prompting | AI guesses requirements; diverges from intent | Use spec as context, not free-form prompts |
+| Skipping the plan phase | Implementation diverges from architecture | Always generate and approve plan before tasks |
+| One giant prompt | Context overload; AI loses focus | Break into tasks; one task per session |
+| Reviewing code instead of specs | Spec becomes stale; no single source of truth | Review each spec artifact before proceeding |
+| Spec sprawl | Too many files; review burden increases | Keep spec folder focused — one folder per feature |
+| AI as sole author | Hallucinations go uncaught | Human verifies every phase gate |
+| **SpecFall** | Installing SpecDD ceremonies without changing how teams actually collaborate — produces "markdown monsters" of stale docs | Treat specs as the **conversation medium** between stakeholders, not just technical output; ensure product, arch, eng, and QA all contribute to their phase |
+| Spec too code-like | Spec becomes near-identical to code; review burden kills adoption | Keep specs "human reviewable" — define intent and behavior, not implementation mechanics |
+| Solo speccing | One developer goes through the entire SpecDD process alone, missing cross-functional insight | Use SpecDD as a collaborative dialogue tool; cross-functional specs are superior to individual prompt optimization |
+
+---
+
+## The Cumulative Quality Problem
+
+Reviewing each SpecDD phase before proceeding is not optional ceremony — it is a mathematical structural requirement.
+
+Each phase, independently, delivers roughly **80% accuracy** under real-world conditions. Without intermediate validation, quality compounds:
+
+$$0.8 \times 0.8 \times 0.8 \times 0.8 \times 0.8 \approx 0.33$$
+
+> Across five phases without review gates, roughly one-third of the intended quality survives to implementation.
+
+This is why SpecDD review gates exist. Every missed inaccuracy — a slightly wrong user story, an incomplete data model, an ambiguous task scope — multiplies through downstream phases. A phase-gate review captures the error while it's cheap to fix.
+
+**Operational implication:** Build your SpecDD process assuming ~80% per-phase accuracy and design review checkpoints accordingly. Shortcutting one gate rarely saves meaningful time; it typically shifts effort into more expensive rework downstream.
+
+---
+
+## Review Fatigue: An Operational Reality
+
+SpecDD shifts cognitive effort from *writing code* to *validating AI-generated artifacts*. This is a favorable shift — but it comes with a real and often underestimated cost: **review fatigue**.
+
+AI-generated markdown appears grammatically correct and architecturally plausible. Unlike code, where structural errors are often visually obvious, spec and plan artifacts require **sustained conceptual attention** to validate correctly. Errors hide in plausible phrasing.
+
+**Practical mitigations:**
+- Treat each spec file like a code review — line by line for critical sections
+- Rotate who conducts reviews; sustained focus depletes quickly
+- Take breaks between reviewing different artifact types (spec vs. plan vs. tasks)
+- Use structured review checklists to keep focus anchored to specific questions
+
+> "The mental effort doesn't disappear — it shifts from typing to validation. Be prepared: it will be tedious. This is the tax you pay for AI assistance." — EPAM AI/Run team, production deployment retrospective
+
+---
+
+## Developer Role Evolution
+
+SpecDD changes not just the workflow, but the nature of developer work itself:
+
+| Traditional Development | SpecDD-Augmented Development |
+|---|---|
+| Write code | Design systems; validate AI output |
+| Review syntax and style | Review architecture and spec alignment |
+| Implementation-first | Specification-first |
+| Discover complexity mid-build | Resolve complexity upstream in specs and plans |
+| Value measured by code written | Value measured by quality of decisions made |
+
+As the **safe delegation window** grows — from AI handling isolated 10–20 minute tasks to handling multi-hour, multi-component feature delivery with consistent quality — developer leverage multiplies. More time on upstream design produces compounding returns: a better plan produces better tasks, which produces better code, with less rework at every stage.
+
+> "Development shifts left. Teams spend more time upstream on system design, scoping, architecture, and planning, and less on typing code. The important work happens before implementation, not during it." — EPAM AI/Run team
+

--- a/docs/starter-guide.md
+++ b/docs/starter-guide.md
@@ -1,0 +1,493 @@
+# Spec-Driven Development Starter Kit — Comprehensive Guide
+
+> **Language-agnostic. Greenfield and brownfield. AI-assisted development, done right.**
+
+Spec-Driven Development (SpecDD) is an AI-assisted methodology where a structured specification becomes the primary artifact and source of truth for software projects. Rather than writing code first, teams collaboratively author human-readable specs that describe *what* to build and *why*, then use AI tools to generate the *how* (the implementation). The result is a paradigm shift: intent expressed in specifications drives the coding process, enabling more clarity, alignment, and automation.
+
+This guide provides a comprehensive blueprint for adopting SpecDD in both greenfield projects (new builds) and brownfield projects (existing codebases). It covers the recommended project structure, spec authoring practices, AI prompt guidelines, role ownership, and integration with DevOps pipelines.
+
+---
+
+## SpecDD Workflow Overview: From Spec to Code
+
+SpecDD breaks the development process into clear phases that interlock to produce high-quality code from high-level intent. Before coding starts, teams invest effort in specification and planning, which the AI then uses to generate robust code.
+
+```
+Phase 0 — Context      Define the project constitution, architecture, and tech stack
+Phase 1 — Specify      Author the spec: user stories, outcomes, acceptance criteria
+Phase 2 — Plan         Generate a technical plan: modules, APIs, data models
+Phase 3 — Tasks        Decompose the plan into ordered, testable implementation tasks
+Phase 4 — Implement    Execute tasks one-by-one with AI; review each increment
+```
+
+> **Tip: SpecDD is iterative, not linear.** Teams frequently loop back to earlier phases based on what's learned later. If the AI uncovers ambiguities during the Plan or Implement phase, revisit and clarify the Spec (using `/sdd-clarify`). Embrace these feedback loops — they prevent costly rework by catching misunderstandings early. Validate intent and design *before* writing large amounts of code.
+
+---
+
+## Project Structure
+
+The SpecDD Starter Kit provides a clear, scalable structure for organizing both specifications and code. Specs are tracked alongside code, organized by lifecycle phase, and prepared for automation.
+
+```
+sdd-kit/                             ← Copy this folder into your project root
+├── README.md                        ← Kit overview + SpecDD levels + slash command reference
+├── SETUP.md                         ← Step-by-step setup guide (start here)
+│
+├── context/                         ← Phase 0: Project-level source of truth
+│   ├── project.md                   ← Project identity, problem, personas, outcomes
+│   ├── constitution.md              ← Coding standards, architectural rules, constraints
+│   ├── architecture.md              ← Architectural decisions and patterns
+│   └── tech-stack.md                ← Approved languages, frameworks, libraries
+│
+├── .github/
+│   ├── copilot-instructions.md      ← Workspace-level AI agent instructions
+│   ├── instructions/                ← Auto-loaded instruction files
+│   │   ├── governance.instructions.md
+│   │   ├── sdd-workflow.instructions.md
+│   │   ├── agent-behavior.instructions.md
+│   │   ├── swagger-api-docs.instructions.md  ← OpenAPI/Swagger rules
+│   │   └── motif-design-system.instructions.md  ← EY Motif design rules
+│   ├── agents/                      ← SpecDD agent definition files
+│   │   ├── sdd-specify.agent.md
+│   │   ├── sdd-implement.agent.md
+│   │   └── sdd-orchestrator.agent.md
+│   └── prompts/                     ← Slash commands
+│       ├── sdd-specify.prompt.md
+│       ├── sdd-plan.prompt.md
+│       ├── sdd-tasks.prompt.md
+│       ├── sdd-implement.prompt.md
+│       └── ...
+│
+├── governance/                      ← Cross-team governance (L1–L3)
+│   ├── enterprise-constitution.md   ← L1: Enterprise-wide rules
+│   ├── blueprints/                  ← L2: BU reference architectures
+│   └── domain-specs/                ← L3: Domain namespace and shared models
+│
+├── specs/                           ← Feature-level specs (one folder per feature)
+│   ├── _template/                   ← Copy this for each new feature
+│   │   ├── spec.md
+│   │   ├── plan.md
+│   │   ├── tasks.md
+│   │   ├── api.md
+│   │   └── data-model.md
+│   └── 001-[feature-name]/
+│       └── ...
+│
+├── docs/                            ← Kit documentation (this folder)
+│   ├── starter-guide.md             ← This file
+│   ├── sdd-methodology.md
+│   ├── workflow.md
+│   ├── greenfield-vs-brownfield.md
+│   ├── faq.md
+│   └── references.md
+│
+├── templates/                       ← Reusable document templates
+├── examples/                        ← Example specs and plans
+└── website/                         ← Wizard UI (generates a configured kit as a ZIP)
+```
+
+This structure ensures that specifications are tracked alongside code and organized by lifecycle stage. In a mature SpecDD project, each new feature has artifacts across all phases. Because everything is under version control, the history of changes to specs and code is visible and traceable.
+
+> **Treating specs as first-class artifacts in your pipeline — not static docs on a wiki — is key to successful SpecDD integration.**
+
+---
+
+## Governance Levels
+
+Many SpecDD frameworks align spec activities to governance levels, particularly in enterprise settings. This kit uses four levels:
+
+| Level | Location | Scope | Generated by |
+|---|---|---|---|
+| **L1 — Enterprise** | `governance/enterprise-constitution.md` | Org-wide standards, compliance | Provided by your org |
+| **L2 — Blueprint** | `governance/blueprints/[bu]/blueprint.md` | BU reference architectures | `/sdd-blueprint` |
+| **L3 — Domain** | `governance/domain-specs/[d]/domain-spec.md` | Domain namespace, shared models | `/sdd-domain-spec` |
+| **L4 — Product** | `context/constitution.md` | Product-level standards and rules | `/sdd-constitution` |
+
+Governance ensures that a feature cannot proceed to implementation until earlier-level constraints are understood and reflected in the product constitution. This imposes quality control at each level, which is valuable for organizations adopting SpecDD at scale. Lower-level governance cannot override a higher level.
+
+---
+
+## Blueprint for Effective Spec Generation
+
+Authoring a good spec is an art. It must be comprehensive yet clear, giving the AI just enough guidance to act correctly without overwhelming it.
+
+### Start with Vision and Scope
+
+Begin the spec with a concise overview of the feature or project. Define the problem being solved, the target users, and the desired outcomes or success metrics. This high-level context sets the stage for the AI — akin to an executive summary of a Product Requirements Document (PRD).
+
+### Adopt a Structured Format
+
+Organize the spec into clear sections. This mirrors how product requirement documents are written and helps the AI understand different aspects of the system:
+
+- **User Stories & Use Cases** — Persona-driven narratives: *"As a [persona], I want to [action], so that [outcome]"*
+- **Functional Requirements** — Specific capabilities and behaviors the system must have, including edge cases and error handling
+- **Non-Functional Requirements** — Performance targets, security/compliance needs, UI/UX guidelines (e.g. WCAG 2.1 AA accessibility), OpenAPI documentation requirements
+- **Boundaries & Out-of-Scope** — Explicit statement of what the system will *not* do; prevents the AI from solving the wrong problem
+
+### Be Clear, Unambiguous, and Testable
+
+Write requirements in a behavioral, verifiable way. Each statement should be something you can test or observe in the final product. Avoid vague language like "the system will be user-friendly" — instead, specify "the system will allow users to complete the checkout process in no more than 3 clicks."
+
+If the specification is too lengthy or unclear, break it into smaller features or multiple specs. An overly large spec can overwhelm both readers and the AI's context window, reducing effectiveness.
+
+### Embed Examples and Edge Cases
+
+Provide illustrative examples, sample inputs/outputs, or mini use-case tables. These act as built-in test cases and reduce ambiguity. They also help the AI verify its outputs during generation — the AI can be prompted to self-check against the spec's examples.
+
+### Leverage Self-Checks and Constraints
+
+You can incorporate AI directives within the spec (in clearly marked sections) that the agent must adhere to. For example:
+
+- *"Performance: All API responses must return in <200ms at P95"*
+- *"Security: Never store passwords in plaintext; hash with bcrypt (cost 12+)"*
+- *"API: All endpoints must have OpenAPI annotations — see `.github/instructions/swagger-api-docs.instructions.md`"*
+
+Some teams add an "always/never" list in `context/constitution.md`, such as *"Always sanitize user input for XSS. Never log sensitive PII."* These act as guardrails for the AI during code generation.
+
+### Iterate and Refine
+
+Treat spec-writing as an iterative process. Use `/sdd-clarify` after the first spec draft — the AI asks questions about unclear parts of the spec, helping you spot ambiguities or gaps. Continually update the spec as new decisions are made or new insights arise, keeping it synchronized with reality. This avoids the "stale documentation" problem: specs that pile up but no one updates.
+
+### One Feature per Spec
+
+Keep each spec focused on a single feature or change set, especially in large projects. This makes the spec easier to review and allows the AI to generate code in manageable batches. For complex features, use hierarchical specs — a high-level spec with links to more detailed sub-specs for different components.
+
+### Brownfield: Create Specs for Existing Functionality
+
+In legacy systems, generate specs from existing code as a starting point:
+
+- **Manual reverse-engineering** — Read code and user documentation to write a descriptive spec
+- **AI-assisted documentation** — Prompt your AI agent to summarize existing code into spec-like descriptions
+- **Incremental coverage** — Focus on one area that needs change; write a spec for that portion, then gradually expand
+
+The key is to *progressively* introduce specs without attempting to document the entire legacy system at once. Prioritize sections you plan to modify or that frequently cause issues. See [docs/greenfield-vs-brownfield.md](greenfield-vs-brownfield.md) for a detailed comparison.
+
+---
+
+## Blueprint for AI-Assisted Code Generation
+
+With well-crafted specs in hand, the next focus is turning specifications into working code through the Plan, Tasks, and Implementation phases.
+
+### Phase 1 — Specify: `/sdd-specify`
+
+Run `/sdd-specify` in Copilot Chat to author or refine `specs/[feature]/spec.md`. The prompt will ask for:
+
+- **What** you're building (user stories, journeys, outcomes)
+- **Why** it matters (business goals, personas, problem statement)
+- **Acceptance criteria** (verifiable, testable conditions for "done")
+
+Use `/sdd-clarify` after the spec draft to resolve open questions. The AI will surface ambiguities; address each one before proceeding.
+
+### Phase 2 — Plan: `/sdd-plan`
+
+Once a spec is reviewed, run `/sdd-plan` to generate a detailed technical plan in `specs/[feature]/plan.md`. The prompt accepts:
+
+- The spec as context
+- Architectural constraints from `context/architecture.md` and `context/tech-stack.md`
+- Integration points: *"This feature touches the existing notification service — reuse it"*
+- Output structure: architecture overview, data model changes, API/interface design, task list shape, testing strategy
+
+After the AI generates the plan, review it critically. Ensure it aligns with the spec and makes sound technical choices. Pay attention to whether it invents new components that duplicate what's already present — if so, add a rule to `context/constitution.md` (e.g. *"Code duplication is prohibited — always search for existing utilities before writing new ones"*) and regenerate.
+
+The plan phase is your chance to catch architectural problems on paper rather than in code.
+
+### Phase 3 — Tasks: `/sdd-tasks`
+
+With a solid plan, run `/sdd-tasks` to derive a set of actionable tasks in `specs/[feature]/tasks.md`. Each task should be:
+
+- **Granular and sequential** — each results in a testable outcome
+- **Scoped to 1–2 files** — this is the core SpecDD constraint that keeps AI output quality high
+- **Traced to acceptance criteria** — so every AC is covered by at least one task
+
+Example task list for an API feature:
+
+```
+- [ ] Update database schema: add Feedback table (columns: id, user_id, text, created_at)
+- [ ] Implement POST /api/v1/feedback — validate input, persist, return 201
+- [ ] Add OpenAPI annotation to POST /feedback (operationId: createFeedback, all responses documented)
+- [ ] Add OpenTelemetry trace span to feedback submission flow
+- [ ] Write unit tests for FeedbackService: validation, save, error cases (target 80% coverage)
+- [ ] Write integration test for POST /api/v1/feedback endpoint
+```
+
+Use `/sdd-analyze` to verify traceability: all acceptance criteria from the spec must be covered by at least one task. If the task still seems too large, break it down further.
+
+### Phase 4 — Implement: `/sdd-implement`
+
+Run `/sdd-implement` to execute tasks one by one. For each task, the AI receives:
+
+- The task description and its acceptance criteria
+- Relevant context from the spec and plan
+- Rules from `context/constitution.md` (coding standards, forbidden patterns, reuse requirements)
+- Instruction files from `.github/instructions/` (e.g. OpenAPI rules, design system rules)
+
+After each task, review the AI-generated code:
+
+| Check | How |
+|---|---|
+| **Fulfils spec?** | Compare against acceptance criteria; run the examples from the spec |
+| **Follows standards?** | Run linters, formatters, static analysis |
+| **No regressions?** | Run the full test suite; investigate any failures |
+| **No duplication?** | Verify the AI didn't re-implement existing utilities |
+| **API documented?** | All new endpoints have OpenAPI annotations (see `.github/instructions/swagger-api-docs.instructions.md`) |
+
+This spec-to-code cycle continues until all tasks are completed and the feature fully satisfies the spec.
+
+After implementation, update the spec with any additional detail discovered: record architecture decisions (use `/sdd-adr`), note performance findings, and document integration constraints. This keeps the spec an up-to-date truth source for future reference.
+
+### Human in the Loop
+
+SpecDD does not mean "set and forget" — human oversight is essential at each step. Developers and architects play a verification role, ensuring AI outputs are correct and making adjustments to specs or prompts as needed. This review-and-refine process catches misunderstandings early and steers the AI before code hits production.
+
+Plan for code reviews and testing just as you would in a normal development process. SpecDD shifts those activities earlier, when fixes are cheapest.
+
+---
+
+## DevOps & Tooling Integration
+
+Adopting SpecDD is not just a writing exercise — it is a change to your development workflow. The following covers integrating SpecDD with DevOps, source control, and CI/CD.
+
+### Version Control & Collaboration
+
+All spec documents must be kept in Git alongside the code. A feature branch for "Add Feedback Feature" should contain commits for the spec *before or together with* commits for code changes.
+
+Establish pull request reviews for specs just as you do for code. This ensures product managers, BAs, and architects can review and approve the plan before any code is written. Some teams designate spec reviewers — with domain or UX expertise — separate from code reviewers.
+
+> **A healthy SpecDD process treats spec changes as a necessary precursor to code changes.** This mindset shift results in far fewer mid-implementation course corrections.
+
+### CI/CD Pipeline Stages
+
+Extend your CI/CD pipeline to incorporate spec-driven stages:
+
+**Spec Validation Stage**
+Lint and validate specs on each commit or pull request. For API specs, run an OpenAPI linter (e.g. [Spectral](https://github.com/stoplightio/spectral)) to catch errors or deviations from style guides. For custom markdown spec formats, write scripts to validate required sections or check formatting. Automated spec validation ensures consistency and catches omissions early.
+
+**Testing & Alignment Stage**
+After code is generated, run the test suites (unit, integration, e2e) to verify that the code satisfies the spec. If you have traceability (AI labels generated code with references to spec sections), create a spec-to-test traceability report in CI. Failing tests signal misalignment or bugs, prompting a spec update or code fix before merge.
+
+**Quality Gates**
+Integrate additional quality gates tied to spec content:
+
+- **Security scan** — if the spec includes security requirements (e.g. "all inputs must be validated"), include SAST or OWASP scanning
+- **Performance test** — if the spec defines a performance SLA, include a load test that validates it
+- **Coverage gate** — if `context/constitution.md` specifies a minimum test coverage threshold, enforce it in CI
+- **API completeness check** — validate that all new endpoints have OpenAPI annotations and that the spec file is valid
+
+**Deployment & Release**
+Use specifications to drive deployment automation. Infrastructure-as-code definitions can be derived from deployment specs. Some teams generate release notes from spec content at this stage, ensuring documentation is current by the time of release.
+
+### OpenTelemetry & Observability Integration
+
+Plan for observability in your specs and code generation tasks. In the Plan phase, include requirements such as:
+
+> *"Use OpenTelemetry for distributed tracing and metrics. Each HTTP handler must create a trace span. Span names follow the convention `[service].[operation]`."*
+
+Make this a standard task in every feature's task list:
+
+> *"Add OpenTelemetry trace span to [operation] — include user_id and request_id as span attributes."*
+
+Document your monitoring and alerting requirements in `context/architecture.md` or a dedicated `specs/ops/observability.md`. Configure your CI/CD pipeline to deploy or update observability components automatically — for example, registering new endpoints with your APM tool or generating dashboards from the spec's SLA definitions.
+
+### Project Constitution: Rules & Standards
+
+`context/constitution.md` is the most important file in the kit. It encodes your engineering standards, compliance rules, and best practices that all specs and code must adhere to. Examples:
+
+- **Coding standards** — linting rules, naming conventions, import ordering
+- **Security and compliance** — OWASP Top 10 requirements, GDPR/data privacy rules, secrets management
+- **Observability** — "All services must emit telemetry using OpenTelemetry SDK. Every major user action must be logged with a trace ID."
+- **API documentation** — "Every public endpoint MUST have an OpenAPI annotation. Swagger UI MUST NOT be exposed in production." (see `.github/instructions/swagger-api-docs.instructions.md`)
+- **Reuse and architecture** — "Code duplication is prohibited — search for existing utilities before writing new ones. Follow the architecture defined in `context/architecture.md`."
+- **Frontend design** — If using Motif Design System: "Always use Motif design tokens. Never hard-code colour or spacing values." (see `.github/instructions/motif-design-system.instructions.md`)
+
+This "spec of specs" is loaded into the AI's context for all phases via `.github/copilot-instructions.md` and the `governance.instructions.md` instruction file, enforcing these rules globally. When your team discovers new pitfalls — for example, the AI creating redundant modules — update `context/constitution.md` so future generations avoid those issues.
+
+### Continuous Alignment and Drift Management
+
+Integration with source control and CI enables continuous alignment between the spec and the code. Consider implementing a drift check — a script or test suite that compares the spec (expected behaviour) with the application's actual behaviour — to detect if code has diverged from the spec over time.
+
+Options include:
+- **API contract testing** — run Dredd or Schemathesis against your OpenAPI spec and deployed service to verify they match
+- **Scheduled test runs** — a nightly job that re-runs your full spec-traced test suite and flags any new failures
+- **Spec review cadence** — a recurring team session (e.g. every sprint) to review specs against the current codebase
+
+---
+
+## Role-Based Spec Artifact Ownership
+
+A crucial aspect of SpecDD is clarity on *who* is responsible for each part of the specification. The table below outlines key spec artifacts and their primary owners:
+
+| Spec Artifact | Primary Owner | Collaborators |
+|---|---|---|
+| `context/project.md` — Project identity, personas, problem statement | Product Owner | BA, Architect |
+| `context/constitution.md` — Coding standards, architectural rules | Lead Architect / Tech Lead | All engineers |
+| `context/architecture.md` — Architectural decisions, patterns | Architect | Engineers |
+| `context/tech-stack.md` — Approved languages, frameworks, packages | Tech Lead | Team |
+| `governance/enterprise-constitution.md` (L1) | Enterprise Architecture | CTO org |
+| `governance/blueprints/` (L2) | BU Architect | Enterprise Arch |
+| `governance/domain-specs/` (L3) | Domain Lead | BU Architect |
+| `specs/[feature]/spec.md` — User stories, acceptance criteria | Product Owner / BA | UX, QA |
+| `specs/[feature]/plan.md` — Technical plan, modules, interfaces | Architect / Tech Lead | Engineers |
+| `specs/[feature]/tasks.md` — Implementation task breakdown | Tech Lead | Developers |
+| `specs/[feature]/api.md` — API contracts, OpenAPI spec | Backend Lead | Frontend, QA |
+| `specs/[feature]/data-model.md` — Schema, ER diagrams | Backend Lead | Architect, DBA |
+| `specs/[feature]/test-plan.md` — Test strategy, coverage targets | QA Lead | Developers |
+| `specs/ops/observability.md` — Monitoring, alerting, OTel config | DevOps Lead | Architect |
+| `specs/ops/deployment.md` — Environment config, release runbook | DevOps Lead | Tech Lead |
+
+Each role should populate and maintain their respective sections, but all team members collaborate to review and ensure consistency across the full spec set. This division of responsibilities reinforces that **SpecDD is a team sport** — it improves collaboration between stakeholders by giving everyone a common medium (the spec) to contribute to.
+
+---
+
+## How to Get Started
+
+### Option A — Use the Wizard (Recommended)
+
+The SpecDD Starter Kit includes a setup wizard at `website/` that generates a complete, pre-configured kit as a downloadable ZIP. Run it locally:
+
+```bash
+cd sdd-kit/website
+npm install
+npm run dev
+# Open http://localhost:4321
+```
+
+The wizard walks through your project details, tech stack, governance level, and optional integrations (Motif Design System, OpenAPI/Swagger docs, MCP tools, agent preferences). It outputs a ZIP containing all 80+ kit files plus project-specific context files ready to drop into your repository.
+
+### Option B — Manual Setup
+
+1. Copy `sdd-kit/` into your project root
+2. Follow [SETUP.md](../SETUP.md) step by step
+3. Generate context files:
+
+```
+/sdd-blueprint         → governance/blueprints/[bu]/blueprint.md   (L2 if needed)
+/sdd-domain-spec       → governance/domain-specs/[d]/domain-spec.md (L3 if needed)
+/sdd-constitution      → context/constitution.md                    (L4 — always)
+/sdd-context-map       → context/architecture.md                    (L4 — recommended)
+```
+
+4. Fill in `context/project.md` and `context/tech-stack.md`
+5. Run your first feature cycle: `/sdd-specify` → `/sdd-plan` → `/sdd-tasks` → `/sdd-implement`
+
+---
+
+## Initial Steps in a New SpecDD Project
+
+### 1. Define the Constitution First
+
+Before writing any code, articulate your project's overarching standards in `context/constitution.md`. Run `/sdd-constitution` and fill in:
+
+- Coding standards and style
+- Architectural principles (which patterns to use, which to avoid)
+- Performance and observability requirements
+- Security and compliance constraints
+- API documentation requirements
+- Reuse rules (e.g. "always check for existing utilities")
+
+Have your senior engineers review this file. Refine it over time as your team discovers new pitfalls or standards.
+
+### 2. Create High-Level Context (Phase 0 docs)
+
+Using the provided templates, have the responsible roles draft the initial project context:
+
+- **Greenfield** — Define `project.md` from scratch with goals, personas, and vision
+- **Brownfield** — Start by documenting the current-state architecture in `architecture.md` and approved stack in `tech-stack.md`; the constitution should describe what *exists* before describing what is *aspirational*
+
+### 3. Leverage the AI for Spec Detailing
+
+Use your AI assistant to expand the specs. Feed it the user stories and ask for a formatted requirements list, or have it draft acceptance criteria for each story. Always review and edit the AI's output — ensure it matches real intent. Remove any extra features the AI added that weren't requested.
+
+This is the "clarify and verify" loop: the AI helps you quickly draft content, and you refine it with domain knowledge.
+
+### 4. Review Specs with the Team
+
+Convene a short review session where each role reads the relevant parts of the spec:
+
+- **Architects** — verify feasibility and enterprise architecture alignment
+- **QA leads** — confirm testability of each acceptance criterion
+- **Product stakeholders** — confirm business alignment
+
+Resolve any ambiguities in the spec now. This is far cheaper than discovering misunderstandings after code is written. Think of it as a spec-centred backlog grooming session.
+
+### 5. Proceed with Plan and Task Generation
+
+Once the spec is solid and reviewed, move to Plan and Tasks:
+
+```
+/sdd-plan     → specs/[feature]/plan.md
+/sdd-tasks    → specs/[feature]/tasks.md
+/sdd-analyze  → verify all ACs are covered by tasks
+```
+
+For a brownfield project or complex integration, apply this cycle to one module or component at a time. Consider a small spike first to validate the approach before committing to a full project.
+
+### 6. Iterate and Scale Up
+
+After implementing a few features with SpecDD, gather metrics and feedback. Track improvements such as:
+
+- Reduced development time per feature
+- Fewer bugs and regressions (due to thorough up-front design)
+- Faster onboarding (new developers read specs to understand the system)
+- Reduction in cycle time from spec to deployment
+
+Use these metrics to demonstrate the value of SpecDD to stakeholders. As confidence grows, expand the practice to more teams and integrate more of the advanced CI/CD automations: fully automated API contract testing, spec drift detection, and automated documentation generation.
+
+---
+
+## Slash Command Quick Reference
+
+| Command | Phase | Output |
+|---|---|---|
+| `/sdd-blueprint` | Governance | `governance/blueprints/[bu]/blueprint.md` |
+| `/sdd-domain-spec` | Governance | `governance/domain-specs/[d]/domain-spec.md` |
+| `/sdd-constitution` | Context (Phase 0) | `context/constitution.md` |
+| `/sdd-context-map` | Context (Phase 0) | `context/architecture.md` |
+| `/sdd-specify` | Phase 1 | `specs/[feature]/spec.md` |
+| `/sdd-clarify` | Phase 1 | Clarification questions + spec updates |
+| `/sdd-plan` | Phase 2 | `specs/[feature]/plan.md` |
+| `/sdd-tasks` | Phase 3 | `specs/[feature]/tasks.md` |
+| `/sdd-analyze` | Phase 3 | Traceability report (ACs → tasks) |
+| `/sdd-checklist` | Any | Quality checklist for current phase |
+| `/sdd-implement` | Phase 4 | Code + tests (task by task) |
+| `/sdd-code-review` | Phase 4 | Code review against spec and standards |
+| `/sdd-adr` | Any | `specs/[feature]/adr-[n].md` |
+| `/sdd-spike` | Any | Time-boxed technical investigation |
+
+---
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Description | Prevention |
+|---|---|---|
+| **SpecFall** | Up-front spec written once, never updated; quickly becomes stale | Treat spec as a living document; update it in every PR that changes behaviour |
+| **Markdown Monster** | Specs pile up but no one maintains them | Assign clear owners; include spec updates in the definition-of-done |
+| **Scope Creep in Spec** | One spec tries to cover 3 features | One feature per spec; use hierarchical specs for complex domains |
+| **Missing Constitution** | AI generates code without knowing your standards | Always define `context/constitution.md` before Phase 1 |
+| **Code Duplication** | AI re-implements existing utilities | Add "check for existing utilities before writing new" to `constitution.md` |
+| **Undocumented APIs** | Backend routes added without OpenAPI annotations | Add API documentation gate to CI; see `swagger-api-docs.instructions.md` |
+| **Unverified AI Output** | AI-generated code merged without review | Mandatory PR review gate; spec-traced test suite in CI |
+| **Big-Bang Generation** | Generating entire codebase in one AI call | Decompose to task level; max 1–2 files per task |
+
+---
+
+## Summary
+
+By following this starter kit, you have a blueprint for Spec-Driven Development that covers everything from initial specs to continuous deployment. SpecDD represents a shift to treating specifications as executable knowledge — a shift that, when supported by AI tools and proper process, results in more robust code, faster delivery, and better collaboration.
+
+Success with SpecDD is not just about tooling. It is about the disciplined practice of keeping specs at the heart of your development process. With a strong spec foundation, clear role ownership, and tight DevOps integration, your team can confidently leverage AI to accelerate software delivery while maintaining a single source of truth from idea to production.
+
+---
+
+## Related Documents
+
+| Document | Description |
+|---|---|
+| [README.md](../README.md) | Kit overview, SpecDD levels, and slash command reference |
+| [SETUP.md](../SETUP.md) | Step-by-step setup guide |
+| [docs/sdd-methodology.md](sdd-methodology.md) | Deep dive into SpecDD concepts and AI constraints |
+| [docs/workflow.md](workflow.md) | Visual workflow reference with phase diagrams |
+| [docs/greenfield-vs-brownfield.md](greenfield-vs-brownfield.md) | Detailed comparison and recommended sequences |
+| [docs/faq.md](faq.md) | Frequently asked questions |
+| [docs/references.md](references.md) | Industry references and further reading |
+| `.github/instructions/swagger-api-docs.instructions.md` | OpenAPI / Swagger documentation standards |
+| `.github/instructions/motif-design-system.instructions.md` | EY Motif Design System rules |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,182 @@
+# SpecDD Workflow Reference
+
+> Visual and textual reference for the end-to-end SpecDD workflow.
+
+---
+
+## Complete Workflow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│              GOVERNANCE SETUP (One-time, team-level)            │
+│                                                                 │
+│  /sdd-blueprint   → governance/blueprints/[bu]/blueprint.md     │
+│  /sdd-domain-spec → governance/domain-specs/[d]/domain-spec.md  │
+│                                                                 │
+│  (Skip if no BU/domain governance applies to your project)      │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: Governance docs reviewed & approved
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     PHASE 0: Context                        │
+│                   (One-time project setup)                      │
+│                                                                 │
+│  constitution.md → architecture.md → tech-stack.md → project.md │
+│  (constitution.md references governance/ files via Inherits From)│
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: Context complete & approved
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    PHASE 1: SPECIFY                              │
+│              /sdd-specify → spec.md                             │
+│                                                                 │
+│  Input: What + Why (user journeys, outcomes, acceptance criteria)│
+│  Output: spec.md (user stories, ACs, journeys)                  │
+│                                                                 │
+│  Optional: /sdd-clarify to resolve open questions               │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: Spec reviewed, no blocking questions
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     PHASE 2: PLAN                                │
+│              /sdd-plan → plan.md                                │
+│                                                                 │
+│  Input: Tech stack, architecture, constraints                    │
+│  Output: plan.md, data-model.md, api.md                         │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: Plan reviewed, technically sound
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    PHASE 3: TASKS                                │
+│              /sdd-tasks → tasks.md                              │
+│                                                                 │
+│  Input: spec.md + plan.md                                       │
+│  Output: tasks.md (ordered, traced to ACs)                      │
+│                                                                 │
+│  Optional: /sdd-analyze for traceability check                  │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: All ACs covered, ordering correct
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  PHASE 4: IMPLEMENT                              │
+│              /sdd-implement (task by task)                      │
+│                                                                 │
+│  Input: tasks.md, spec.md, plan.md, constitution.md             │
+│  Output: Working code, tests, documentation                     │
+│                                                                 │
+│  ┌──────────────────────────────────┐                          │
+│  │  For each task:                  │                          │
+│  │  1. AI implements                │                          │
+│  │  2. Run tests                    │                          │
+│  │  3. Human verifies vs spec       │ ◄─── Repeat              │
+│  │  4. Mark [x] + commit            │                          │
+│  └──────────────────────────────────┘                          │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ Gate: All tasks done, checklist passed
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  REVIEW & SHIP                                   │
+│                                                                 │
+│  Complete checklist.md → Code review → Merge → Deploy           │
+│  Update spec.md status to "Implemented"                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase Gate Summary
+
+| Phase | Input | Output | Gate |
+|---|---|---|---|
+| Blueprint (optional) | BU context, enterprise constitution | `governance/blueprints/[bu]/blueprint.md` | BU Architecture Council approved |
+| Domain Spec (optional) | Blueprint, domain knowledge | `governance/domain-specs/[d]/domain-spec.md` | Domain Architects approved |
+| Context | Project knowledge + governance context | 4 context files | All files present & reviewed |
+| Specify | User intent | `spec.md` | Human approves, no blocking questions |
+| Clarify (optional) | `spec.md` | Clarification report | All blockers resolved |
+| Plan | `spec.md` + tech constraints | `plan.md`, `data-model.md`, `contracts/`, `quickstart.md` | Human approves, constitution compliant |
+| Analyze (optional) | spec + plan + tasks | Analysis report | All ACs traceable |
+| Tasks | `spec.md` + `plan.md` | `tasks.md` | All ACs covered, ordering correct |
+| Implement | `tasks.md` + context | Code + tests | All tasks `[x]`, checklist passes |
+
+---
+
+## File Map: What Gets Created When
+
+```
+After /sdd-constitution:
+  context/constitution.md ✅
+  context/project.md ✅
+  context/architecture.md ✅
+  context/tech-stack.md ✅
+
+After /sdd-specify:
+  specs/[NNN]-[feature]/spec.md ✅
+  specs/[NNN]-[feature]/research.md ✅ (empty skeleton)
+
+After /sdd-plan:
+  specs/[NNN]-[feature]/plan.md ✅
+  specs/[NNN]-[feature]/research.md ✅ (Phase 0 — resolved unknowns)
+  specs/[NNN]-[feature]/data-model.md ✅ (Phase 1 — if applicable)
+  specs/[NNN]-[feature]/quickstart.md ✅ (Phase 1 — key validation scenarios)
+  specs/[NNN]-[feature]/contracts/ ✅ (Phase 1 — API/interface contracts)
+
+After /sdd-tasks:
+  specs/[NNN]-[feature]/tasks.md ✅
+
+During /sdd-implement:
+  src/[...] ✅ (implementation files)
+  tests/[...] ✅ (test files)
+  specs/[NNN]-[feature]/tasks.md (updated with [x] marks)
+  specs/[NNN]-[feature]/checklist.md (completed)
+```
+
+---
+
+## Commit Cadence
+
+```bash
+# Phase 0 — after Context
+git commit -m "chore: initialize SpecDD Context"
+
+# Phase 1 — after spec approved
+git commit -m "spec([NNN]): [feature-name] functional specification"
+
+# Phase 2 — after plan approved
+git commit -m "plan([NNN]): [feature-name] technical implementation plan"
+
+# Phase 3 — after tasks approved
+git commit -m "tasks([NNN]): [feature-name] implementation task breakdown"
+
+# Phase 4 — after each task
+git commit -m "feat(T[NNN]): [task-title] — [brief summary]"
+
+# Phase 4 — after feature complete
+git commit -m "feat([NNN]): [feature-name] complete"
+```
+
+---
+
+## When Things Go Wrong
+
+```
+AI output doesn't match spec
+  → Re-read spec. Was the spec clear?
+  → If yes: Give AI more specific prompt referencing exact AC
+  → If no: Fix spec, re-generate
+
+Tests fail unexpectedly
+  → Stop. Check if regression from unrelated change
+  → Fix regression before continuing current task
+
+AI goes out of scope
+  → Reject output. Add explicit "do not implement [X]" to prompt
+  → Reference out-of-scope list in spec.md
+
+Constitutional violation found in code review
+  → Reject output. Cite specific principle.
+  → Add explicit rule to agent-boundaries.md to prevent recurrence
+
+Spec and plan contradict each other
+  → Stop. Resolve in spec or plan (spec wins for requirements)
+  → Never implement ambiguous specifications
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Examples — Reference Library
+
+This folder contains reusable prompts and instructions that are **not part of the core SpecDD workflow** but may be useful for specific situations.
+
+## Why This Exists
+
+The core SpecDD kit is intentionally focused: `specify → plan → tasks → implement`.
+This folder holds everything else — things you might want occasionally, but not on every project.
+
+## Structure
+
+```
+examples/
+  prompts/
+    catalog.md                         ← Full list with source links
+    create-architectural-decision-record.prompt.md
+    create-technical-spike.prompt.md
+    create-github-issues-from-plan.prompt.md
+    context-map.prompt.md
+    refactor-plan.prompt.md
+    what-context-needed.prompt.md
+  instructions/
+    catalog.md                         ← Full list with source links
+    spec-driven-workflow-v1.instructions.md
+    agent-safety.instructions.md
+    no-heredoc.instructions.md
+```
+
+## When to Use
+
+| Situation | Relevant Example |
+|---|---|
+| You need to document an architecture decision | `prompts/create-architectural-decision-record.prompt.md` |
+| You need to research an unknown before speccing | `prompts/create-technical-spike.prompt.md` |
+| You want to map bounded contexts before domain spec | `prompts/context-map.prompt.md` |
+| You want to create GitHub Issues from your tasks | `prompts/create-github-issues-from-plan.prompt.md` |
+| You need to plan a multi-file refactor safely | `prompts/refactor-plan.prompt.md` |
+| You want Copilot to declare what files it needs first | `prompts/what-context-needed.prompt.md` |
+| You want a simpler alternative to the full SpecDD kit | `instructions/spec-driven-workflow-v1.instructions.md` |
+| You need AI safety guardrails for autonomous agents | `instructions/agent-safety.instructions.md` |
+| You need to prevent heredoc file corruption in VS Code | `instructions/no-heredoc.instructions.md` |
+
+## Source
+
+Most examples are adapted from [github/awesome-copilot](https://github.com/github/awesome-copilot) — a community-maintained collection with 22k+ stars. See each file's frontmatter for the original source URL.
+
+## Promoting to Active
+
+To move an example into the active SpecDD workflow, copy it to `.github/prompts/` or `.github/instructions/` and register it in `.github/copilot-instructions.md`.

--- a/examples/instructions/agent-safety.instructions.md
+++ b/examples/instructions/agent-safety.instructions.md
@@ -1,0 +1,92 @@
+---
+applyTo: "**"
+description: Safety guardrails for autonomous AI agents. Applies when Copilot is operating in agent mode with tools — sets scope boundaries, confirmation requirements, and rollback expectations.
+---
+
+# Agent Safety & Governance
+
+These instructions apply when GitHub Copilot is operating **autonomously** with file editing, terminal execution, or external service access. They establish the minimum safety contract between the AI agent and the human operator.
+
+---
+
+## Scope Control
+
+**Do not act outside the stated scope.**
+
+- Identify the exact files, directories, or systems involved in the request before starting
+- If the request is ambiguous about scope, ask before proceeding
+- Do not make changes to files not mentioned in the request unless they are direct dependencies (e.g., imports that must be updated)
+- Do not install packages, create infrastructure, or modify CI/CD unless explicitly asked
+
+**Scope creep is the primary failure mode of autonomous agents.**
+
+---
+
+## Confirmation Requirements
+
+Stop and ask for confirmation before:
+
+- **Deleting** any file, record, or resource
+- **Modifying** a file that appears to be infrastructure, configuration, or deployment-related
+- **Running** any command that writes to a database or external service
+- **Creating** more than 3 new files in a single operation
+- **Modifying** a file that has not been mentioned in the current conversation
+
+---
+
+## Destructive Operations
+
+Before any destructive operation:
+
+1. State what you are about to do
+2. State what will be lost or changed and cannot be automatically reversed
+3. Wait for explicit confirmation (`yes`, `proceed`, `confirm` or similar)
+
+Never perform destructive operations silently.
+
+---
+
+## Rollback Readiness
+
+Before making a sequence of changes:
+
+- Verify the repository is in a clean git state (`git status`)
+- If not clean, recommend committing or stashing before proceeding
+- After completing changes, summarize what was done so the user can run `git diff` to review
+
+For operations that cannot be undone with `git revert`:
+- State this explicitly beforehand
+- Provide manual rollback steps
+
+---
+
+## Error Handling
+
+If a step fails during an autonomous sequence:
+
+1. Stop immediately — do not attempt to work around the failure silently
+2. Report the failure clearly
+3. Describe what state the system is in now
+4. Offer either: (a) fix the error, or (b) roll back to the starting state
+
+**Partial completion is often worse than no change.** Do not leave the system in an inconsistent state.
+
+---
+
+## Governance Compliance
+
+If governance files exist in the project:
+- Read `governance/enterprise-constitution.md` (Level 1) before creating any infrastructure or committing to an architectural pattern
+- Read `context/constitution.md` (Level 4) before generating code for this product
+- Raise a conflict explicitly if the requested action violates governance rules
+
+Do not implement something that violates governance even if the user requests it. Instead, state the conflict and propose a compliant alternative.
+
+---
+
+## Transparency
+
+- **Declare what you are about to do before doing it** when the action affects more than one file
+- **Explain your reasoning** when making a non-obvious decision
+- **Distinguish** between facts ("the spec says X") and inferences ("I'm assuming Y because...")
+- If you are uncertain, say so. Confident hallucination is the worst failure mode.

--- a/examples/instructions/catalog.md
+++ b/examples/instructions/catalog.md
@@ -1,0 +1,94 @@
+# Instructions Catalog
+
+Curated `.instructions.md` files for automatic context loading in GitHub Copilot.
+These apply based on file patterns (`applyTo:`) or globally (`applyTo: "**"`).
+
+**How they work:** Place an instructions file in `.github/instructions/` and add `applyTo:` frontmatter. Copilot loads it automatically when you're working on matching files — no manual `/` command needed.
+
+---
+
+## SpecDD Workflow Instructions
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| [spec-driven-workflow-v1.instructions.md](./spec-driven-workflow-v1.instructions.md) | `**` | Simpler alternative to the full SpecDD kit — single instructions file for spec-driven development | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/spec-driven-workflow-v1.instructions.md) |
+| `task-implementation.instructions.md` | `specs/**/tasks.md` | Progressive task tracking with change records | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/task-implementation.instructions.md) |
+
+## AI Safety & Governance
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| [agent-safety.instructions.md](./agent-safety.instructions.md) | `**` | Guardrails for autonomous AI agents — scope limits, confirmation requirements, rollback | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/agent-safety.instructions.md) |
+| [no-heredoc.instructions.md](./no-heredoc.instructions.md) | `**` | Prevents terminal heredoc file corruption — enforces use of file editing tools over shell redirections | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/no-heredoc.instructions.md) |
+| `ai-prompt-engineering-safety-best-practices.instructions.md` | `**` | Bias mitigation, responsible AI, safety frameworks | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/ai-prompt-engineering-safety-best-practices.instructions.md) |
+| `taming-copilot.instructions.md` | `**` | Prevent Copilot from making changes outside the stated scope | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/taming-copilot.instructions.md) |
+
+## Code Quality & Process
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| `code-review-generic.instructions.md` | `**/*.{ts,js,py,cs,java}` | Generic code review standards | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/code-review-generic.instructions.md) |
+| `object-calisthenics.instructions.md` | `src/**` | Object Calisthenics for clean domain code | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/object-calisthenics.instructions.md) |
+| `performance-optimization.instructions.md` | `**` | Performance best practices across frontend, backend, database | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/performance-optimization.instructions.md) |
+
+## Documentation
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| `markdown.instructions.md` | `**/*.md` | Markdown documentation standards | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/markdown.instructions.md) |
+| `update-docs-on-code-change.instructions.md` | `**/*.{md,js,ts,py,cs,go}` | Automatically keep README, API docs, and changelogs in sync when code changes | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/update-docs-on-code-change.instructions.md) |
+| `context.instructions.md` | `context/**` | Instructions for maintaining the context pattern | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/context.instructions.md) |
+
+## Accessibility
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| `a11y.instructions.md` | `**` | WCAG 2.2 AA accessibility guidance — keyboard navigation, contrast, ARIA, reflow, forced colors | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/a11y.instructions.md) |
+
+## MCP & External Tools
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| `context7.instructions.md` | `**` | Instructs Copilot to use Context7 MCP server for live, version-accurate library documentation | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/context7.instructions.md) |
+
+## DevOps & Infrastructure
+
+| File | applyTo | Description | Source |
+|---|---|---|---|
+| `azure-devops-pipelines.instructions.md` | `**/*.yml` | Azure DevOps Pipeline YAML best practices | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/azure-devops-pipelines.instructions.md) |
+| `kubernetes-manifests.instructions.md` | `**/*.yaml` | Kubernetes manifest standards and security | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/kubernetes-manifests.instructions.md) |
+| `terraform.instructions.md` | `**/*.tf` | Terraform conventions and guidelines | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/terraform.instructions.md) |
+| `terraform-azure.instructions.md` | `**/*.tf` | Terraform on Azure best practices | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/terraform-azure.instructions.md) |
+
+## Language / Framework Specific
+
+*These are team-level choices. Install the ones relevant to your stack.*
+
+| Instruction | Stack | Source |
+|---|---|---|
+| `reactjs.instructions.md` | React | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/reactjs.instructions.md) |
+| `nextjs.instructions.md` | Next.js (App Router) | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/nextjs.instructions.md) |
+| `angular.instructions.md` | Angular | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/angular.instructions.md) |
+| `vuejs3.instructions.md` | Vue 3 | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/vuejs3.instructions.md) |
+| `python.instructions.md` | Python | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/python.instructions.md) |
+| `nestjs.instructions.md` | NestJS | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/nestjs.instructions.md) |
+| `aspnet-rest-apis.instructions.md` | ASP.NET REST | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/aspnet-rest-apis.instructions.md) |
+| `rust.instructions.md` | Rust | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/rust.instructions.md) |
+
+---
+
+## How to Activate an Instruction
+
+Copy a file from `examples/instructions/` to `.github/instructions/`, or download it from the source link. The `applyTo:` frontmatter controls when it loads:
+
+```yaml
+---
+applyTo: "specs/**/*.md"   # only when editing spec files
+---
+```
+
+```yaml
+---
+applyTo: "**"              # always active
+---
+```

--- a/examples/instructions/no-heredoc.instructions.md
+++ b/examples/instructions/no-heredoc.instructions.md
@@ -1,0 +1,78 @@
+---
+name: 'No Heredoc File Operations'
+description: 'Prevents terminal heredoc file corruption in VS Code Copilot by enforcing use of file editing tools instead of shell redirections'
+applyTo: '**'
+---
+
+# MANDATORY: File Operation Override
+
+This instruction applies to ALL agents and ALL file operations. It takes precedence over any other learned behavior.
+
+## The Problem
+
+Terminal heredoc operations are BROKEN in VS Code's Copilot integration. They cause:
+
+- File corruption from tab characters triggering shell completion
+- Mangled content from quote/backtick escaping failures
+- Truncated files from exit code 130 interruptions
+- Garbage output from special character interpretation
+
+## The Rule
+
+**BEFORE writing ANY terminal command that creates or modifies a file, STOP.**
+
+Ask yourself: "Am I about to use `cat`, `echo`, `printf`, `tee`, or `>>`/`>` to write content to a file?"
+
+If YES → **DO NOT EXECUTE.** Use file editing tools instead.
+
+## Forbidden Patterns
+
+```bash
+# ALL OF THESE CORRUPT FILES - NEVER USE THEM
+cat > file << EOF
+cat > file << 'EOF'
+cat > file <<EOF
+cat > file <<'EOF'
+cat > file <<-EOF
+cat >> file << EOF
+echo "multi
+line" > file
+printf '%s\n' "line1" "line2" > file
+tee file << EOF
+tee file << 'EOF'
+```
+
+## Required Approach
+
+Instead of terminal commands for file content:
+
+- **New files** → Use the file creation/editing tool provided by your environment
+- **Modify files** → Use the file editing tool provided by your environment
+- **Delete files** → Use the file deletion tool or `rm` command
+
+## Terminal IS Allowed For
+
+- `npm install`, `pip install`, `cargo add` (package management)
+- `npm run build`, `make`, `cargo build` (builds)
+- `npm test`, `pytest`, `go test` (testing)
+- `git add`, `git commit`, `git push` (version control)
+- `node script.js`, `python app.py` (running existing code)
+- `ls`, `cd`, `mkdir`, `pwd`, `rm` (filesystem navigation)
+- `curl`, `wget` (downloading, but not piping to files with content manipulation)
+
+## Terminal is FORBIDDEN For
+
+- ANY file creation with content
+- ANY file modification with content
+- ANY heredoc syntax (`<<`)
+- ANY multi-line string redirection
+
+## Enforcement
+
+This is not a suggestion. This is a hard technical requirement due to VS Code terminal integration bugs. Ignoring this instruction will result in corrupted files that the user must manually fix.
+
+When you need to create or edit a file:
+
+1. Stop before typing any terminal command
+2. Use the appropriate file editing tool
+3. The tool will handle the content correctly without corruption

--- a/examples/instructions/spec-driven-workflow-v1.instructions.md
+++ b/examples/instructions/spec-driven-workflow-v1.instructions.md
@@ -1,0 +1,91 @@
+---
+applyTo: "**"
+description: Specification-Driven Workflow v1 — a lighter-weight alternative to the full SpecDD kit. Provides a structured approach to software development without the full governance hierarchy. Good for smaller projects or solo developers.
+---
+
+# Specification-Driven Workflow v1
+
+A structured approach to software development that ensures requirements are clearly defined, designs are meticulously planned, and implementations are thoroughly documented and validated.
+
+> **Note:** This is a simplified alternative to the full SpecDD kit. If your project uses `.github/prompts/sdd-*.prompt.md` files, use those instead — they provide more structure, governance hierarchy, and handoff chains.
+
+---
+
+## Core Principle
+
+**Never write code without a spec. Never write a spec without understanding the problem.**
+
+The workflow has four phases:
+
+```
+UNDERSTAND → SPECIFY → PLAN → IMPLEMENT
+```
+
+Each phase produces a document that becomes the input to the next.
+
+---
+
+## Phase 1: Understand
+
+Before writing anything, answer these questions:
+
+- What problem is the user/business trying to solve?
+- Who are the users and what do they actually need?
+- What are the constraints (technical, time, compliance)?
+- What does success look like — measurably?
+
+Ask clarifying questions until these are answered. Do not skip this phase even under time pressure.
+
+---
+
+## Phase 2: Specify
+
+Create `specs/{feature}/spec.md` with:
+
+- **Overview** — What is being built and why
+- **User Stories** — `As a [user], I want [action], so that [benefit]`
+- **Acceptance Criteria** — Testable, unambiguous conditions
+- **Out of Scope** — Explicit list of what is NOT included
+- **Open Questions** — Unresolved decisions that need answers before implementation
+
+**Gate:** The spec is complete when every acceptance criterion is testable and out-of-scope is explicitly listed.
+
+---
+
+## Phase 3: Plan
+
+Create `specs/{feature}/plan.md` with:
+
+- **Architecture** — How will this be built? What components are involved?
+- **Data Model** — What data structures are created or modified?
+- **API Changes** — What interfaces change?
+- **Dependencies** — What does this rely on that doesn't exist yet?
+- **Risks** — What could go wrong, and how will you mitigate it?
+- **Testing Strategy** — How will acceptance criteria be verified?
+
+**Gate:** The plan is reviewed against the spec. Every AC must have a corresponding test approach.
+
+---
+
+## Phase 4: Implement
+
+Execute the plan in small, verifiable increments:
+
+- Implement one acceptance criterion at a time
+- Write tests before or alongside the code
+- Commit with meaningful messages referencing the spec
+- Update the spec if requirements change during implementation (never silently)
+
+**Gate:** All acceptance criteria pass. Code is reviewed.
+
+---
+
+## Agent Behavior Rules
+
+When operating in agent mode on a project using this workflow:
+
+1. **Read the spec first.** Before suggesting any implementation, read `specs/{feature}/spec.md`.
+2. **Raise conflicts.** If the code contradicts the spec, stop and flag it.
+3. **Don't expand scope.** If you identify something useful that is out-of-scope, document it as a future spec, don't implement it now.
+4. **Update docs when code changes.** If implementation differs from the plan, update `plan.md` to reflect the actual approach.
+5. **Ask before deleting.** Never remove existing functionality without explicit instruction.

--- a/examples/prompts/catalog.md
+++ b/examples/prompts/catalog.md
@@ -1,0 +1,95 @@
+# Prompts Catalog
+
+Curated prompts from [github/awesome-copilot](https://github.com/github/awesome-copilot) and other sources.
+Organized by phase and use case.
+
+---
+
+## Pre-Spec: Research & Discovery
+
+| Prompt | Description | Source |
+|---|---|---|
+| [create-technical-spike.prompt.md](./create-technical-spike.prompt.md) | Time-boxed spike document for researching unknowns before spec | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-technical-spike.prompt.md) |
+| [context-map.prompt.md](./context-map.prompt.md) | Map bounded contexts and relationships (DDD) | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/context-map.prompt.md) |
+| [what-context-needed.prompt.md](./what-context-needed.prompt.md) | Ask Copilot what files it needs before answering a question | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/what-context-needed.prompt.md) |
+| `first-ask.prompt.md` | Ask clarifying questions before acting | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/first-ask.prompt.md) |
+
+## Specification & Planning
+
+| Prompt | Description | Source |
+|---|---|---|
+| `breakdown-epic-pm.prompt.md` | Create Product Requirements Documents (PRD) for an Epic | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-epic-pm.prompt.md) |
+| `breakdown-epic-arch.prompt.md` | High-level technical architecture for an Epic | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-epic-arch.prompt.md) |
+| `breakdown-feature-prd.prompt.md` | PRD for a specific feature based on an Epic | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-feature-prd.prompt.md) |
+| `breakdown-feature-implementation.prompt.md` | Detailed feature implementation plan | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-feature-implementation.prompt.md) |
+| `breakdown-test.prompt.md` | Test strategy and quality assurance plan | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-test.prompt.md) |
+
+## Architecture & Design
+
+| Prompt | Description | Source |
+|---|---|---|
+| [create-architectural-decision-record.prompt.md](./create-architectural-decision-record.prompt.md) | Create an ADR for key architectural decisions | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-architectural-decision-record.prompt.md) |
+| `architecture-blueprint-generator.prompt.md` | Analyze codebase and generate architecture documentation | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/architecture-blueprint-generator.prompt.md) |
+| `technology-stack-blueprint-generator.prompt.md` | Document the full technology stack | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/technology-stack-blueprint-generator.prompt.md) |
+| `folder-structure-blueprint-generator.prompt.md` | Analyze and document project folder structure | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/folder-structure-blueprint-generator.prompt.md) |
+
+## GitHub Integration
+
+| Prompt | Description | Source |
+|---|---|---|
+| [create-github-issues-from-plan.prompt.md](./create-github-issues-from-plan.prompt.md) | Create GitHub Issues from an implementation plan | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-github-issues-feature-from-implementation-plan.prompt.md) |
+| `create-github-issue-feature-from-specification.prompt.md` | Create a GitHub Issue from a spec file | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-github-issue-feature-from-specification.prompt.md) |
+| `create-github-issues-for-unmet-specification-requirements.prompt.md` | Issues for unimplemented spec requirements | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-github-issues-for-unmet-specification-requirements.prompt.md) |
+| `create-github-pull-request-from-specification.prompt.md` | Create a PR from a spec file | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-github-pull-request-from-specification.prompt.md) |
+| `breakdown-plan.prompt.md` | Full project plan with Epic > Feature > Story hierarchy + GitHub Issues | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/breakdown-plan.prompt.md) |
+
+## Documentation
+
+| Prompt | Description | Source |
+|---|---|---|
+| `documentation-writer.prompt.md` | Diátaxis-structured technical documentation | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/documentation-writer.prompt.md) |
+| `create-readme.prompt.md` | Generate a comprehensive README.md | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-readme.prompt.md) |
+| `readme-blueprint-generator.prompt.md` | README from copilot-instructions.md patterns | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/readme-blueprint-generator.prompt.md) |
+| `add-educational-comments.prompt.md` | Add explanatory comments to a file | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/add-educational-comments.prompt.md) |
+
+## AI & Copilot Meta
+
+| Prompt | Description | Source |
+|---|---|---|
+| `copilot-instructions-blueprint-generator.prompt.md` | Generate copilot-instructions.md from existing codebase | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/copilot-instructions-blueprint-generator.prompt.md) |
+| `create-agentsmd.prompt.md` | Generate an AGENTS.md file | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-agentsmd.prompt.md) |
+| `create-llms.prompt.md` | Create an llms.txt from repository structure | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/create-llms.prompt.md) |
+| `update-llms.prompt.md` | Update an existing llms.txt | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/update-llms.prompt.md) |
+| `prompt-builder.prompt.md` | Build high-quality Copilot prompts | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/prompt-builder.prompt.md) |
+| `finalize-agent-prompt.prompt.md` | Polish a prompt file from an AI agent perspective | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/finalize-agent-prompt.prompt.md) |
+| `model-recommendation.prompt.md` | Recommend optimal AI models for task types | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/model-recommendation.prompt.md) |
+
+## Refactoring & Code Quality
+
+| Prompt | Description | Source |
+|---|---|---|
+| [refactor-plan.prompt.md](./refactor-plan.prompt.md) | Multi-file refactor with sequencing and rollback | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/refactor-plan.prompt.md) |
+| `refactor-method-complexity-reduce.prompt.md` | Reduce method complexity | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/refactor-method-complexity-reduce.prompt.md) |
+| `review-and-refactor.prompt.md` | Code review + refactor in one pass | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/review-and-refactor.prompt.md) |
+
+## DevOps & Operations
+
+| Prompt | Description | Source |
+|---|---|---|
+| `devops-rollout-plan.prompt.md` | Generate comprehensive deployment rollout plans with preflight checks, verification signals, and rollback procedures | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/devops-rollout-plan.prompt.md) |
+
+## Git Workflow
+
+| Prompt | Description | Source |
+|---|---|---|
+| `conventional-commit.prompt.md` | Generate conventional commit messages using a structured XML format with validation | [source](https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/conventional-commit.prompt.md) |
+
+---
+
+## How to Install from VS Code
+
+Any prompt from awesome-copilot can be installed directly into VS Code:
+
+1. Open the source link above
+2. Use the VS Code install badge on the awesome-copilot page, or
+3. Copy the raw file to `.github/prompts/` in your project

--- a/examples/prompts/context-map.prompt.md
+++ b/examples/prompts/context-map.prompt.md
@@ -1,0 +1,104 @@
+---
+agent: agent
+description: Create a DDD Context Map for a system or domain. Use this before /sdd-domain-spec to identify bounded contexts, their relationships, and integration patterns across a system landscape.
+---
+
+# Context Map
+
+You are a Domain-Driven Design expert. Help the user create a Context Map that makes the bounded contexts and their relationships explicit.
+
+## When to Use This
+
+Run this **before** `/sdd-domain-spec` when:
+- The domain involves multiple teams or services
+- There are integration patterns to document (upstream/downstream, ACL, shared kernel)
+- The system landscape is not well understood
+- You're onboarding a new team to an existing system
+
+## Process
+
+1. **Identify bounded contexts** — Ask the user to list the systems, services, or major functional areas involved. Each gets its own bounded context.
+
+2. **Identify relationships** — For each pair of contexts that interact, classify the relationship type.
+
+3. **Identify integration patterns** — For each relationship, describe how data flows and what translation is needed.
+
+4. **Produce the context map** — Create `docs/context-map.md` with a Mermaid diagram + detailed relationship table.
+
+## Relationship Types
+
+| Type | Abbreviation | Description |
+|---|---|---|
+| Partnership | P | Two teams coordinate tightly, succeed or fail together |
+| Shared Kernel | SK | Teams share a subset of the domain model |
+| Customer/Supplier | C/S | Upstream provides to downstream; downstream influences priorities |
+| Conformist | CF | Downstream conforms to upstream model with no negotiating power |
+| Anticorruption Layer | ACL | Downstream translates upstream model to protect its own model |
+| Open Host Service | OHS | Upstream publishes a protocol for downstream consumption |
+| Published Language | PL | A shared, documented interchange format |
+| Separate Ways | SW | No integration — teams work independently |
+| Big Ball of Mud | BBM | Legacy without clear boundaries (document honestly) |
+
+## Output Template
+
+Save the output to `docs/context-map.md`:
+
+```markdown
+# Context Map: {System Name}
+
+**Date:** {YYYY-MM-DD}  
+**Version:** 1.0
+
+---
+
+## Bounded Contexts
+
+| Context | Team | Core Capability |
+|---|---|---|
+| {Context A} | {Team} | {What it owns} |
+| {Context B} | {Team} | {What it owns} |
+
+---
+
+## Relationships
+
+\`\`\`mermaid
+graph LR
+  A["{Context A}"] -->|"C/S"| B["{Context B}"]
+  B -->|"ACL"| C["{Context C}"]
+  C -->|"OHS + PL"| D["{Context D}"]
+\`\`\`
+
+---
+
+## Relationship Details
+
+### {Context A} → {Context B}
+- **Pattern:** Customer/Supplier (C/S)
+- **Direction:** A is upstream, B is downstream
+- **Data Flow:** {What information crosses the boundary}
+- **Integration:** {HTTP API | event | shared DB | file | etc.}
+- **Translation needed:** {Yes/No — describe any impedance mismatch}
+- **Risk:** {Notes on coupling, latency, failure modes}
+
+{Repeat for each relationship}
+
+---
+
+## Key Risks
+
+- {Overly tight coupling between X and Y}
+- {Shared kernel drift between A and C}
+
+## Recommended Actions
+
+- {Introduce ACL between B and legacy system Z}
+- {Formalize the OHS published language for event schema}
+```
+
+## Guidelines
+
+- Draw the map before writing domain specs — it reveals hidden coupling
+- Be honest about Big Ball of Mud areas; naming them is the first step to fixing them
+- Each bounded context should be owned by one team (Conway's Law applies)
+- After completing, use the context map to scope each `/sdd-domain-spec` call

--- a/examples/prompts/create-architectural-decision-record.prompt.md
+++ b/examples/prompts/create-architectural-decision-record.prompt.md
@@ -1,0 +1,68 @@
+---
+agent: agent
+description: Create an Architectural Decision Record (ADR) for key technical decisions. Use this whenever a decision is made that is hard to reverse, affects multiple teams, or should be understood by future contributors.
+---
+
+# Create Architectural Decision Record (ADR)
+
+You are an experienced software architect. Create a well-structured Architectural Decision Record for the decision described by the user.
+
+## Process
+
+1. **Clarify the decision** — Ask what the decision is, what alternatives were considered, and why it matters. If the user's description is already detailed, skip clarifying questions and proceed.
+
+2. **Identify the context** — What forces, constraints, or requirements led to this decision? What was the status quo?
+
+3. **Document the decision** — Use the ADR template below. Be precise and honest, including trade-offs.
+
+4. **Save the file** — Create `docs/decisions/ADR-{NNN}-{slug}.md` where NNN is the next sequential number. If `docs/decisions/` does not exist, create it.
+
+## ADR Template
+
+```markdown
+# ADR-{NNN}: {Short Title}
+
+**Date:** {YYYY-MM-DD}  
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-{NNN}  
+**Deciders:** {Who was involved in the decision}
+
+---
+
+## Context
+
+{Describe the forces at play: technical, business, social. What is the problem? What constraints exist? Be neutral — this section should make sense even to someone who would have made a different decision.}
+
+## Decision
+
+{State the decision clearly. Use active voice: "We will..." not passive constructions.}
+
+## Consequences
+
+### Positive
+- {Benefit 1}
+- {Benefit 2}
+
+### Negative / Trade-offs
+- {Trade-off 1}
+- {Trade-off 2}
+
+### Neutral
+- {Neutral consequence — things that change but aren't inherently good or bad}
+
+## Alternatives Considered
+
+| Option | Reason Not Chosen |
+|---|---|
+| {Option A} | {Why rejected} |
+| {Option B} | {Why rejected} |
+
+## References
+- {Link to relevant PR, ticket, design doc, RFC, etc.}
+```
+
+## Guidelines
+
+- Keep each ADR focused on **one decision**
+- An ADR is **immutable once accepted** — if the decision changes, create a new ADR that supersedes this one
+- Write for someone joining the project in 2 years who needs to understand why this was done
+- Trade-offs are required — an ADR with no negatives is not credible

--- a/examples/prompts/create-github-issues-from-plan.prompt.md
+++ b/examples/prompts/create-github-issues-from-plan.prompt.md
@@ -1,0 +1,99 @@
+---
+agent: agent
+description: Create GitHub Issues from an implementation plan. Use this after /sdd-tasks to push the task breakdown into a GitHub project for sprint planning, assignment, and tracking.
+tools:
+  - web/githubRepo
+---
+
+# Create GitHub Issues from Implementation Plan
+
+You are a project coordinator. Convert a completed SpecDD implementation plan and task list into GitHub Issues, organized using the Epic > Feature > Story hierarchy.
+
+## Prerequisites
+
+Before running this prompt:
+- `/sdd-tasks` must be complete — `specs/{feature}/tasks.md` must exist
+- The user must be authenticated with GitHub (`gh auth status`)
+- The repository must have GitHub Issues enabled
+
+## Process
+
+1. **Read the task file** — Load `specs/{feature}/tasks.md` and parse all tasks (T001, T002, etc.) and their priorities (P = pink/critical, B = blue/medium, G = green/low).
+
+2. **Read the spec** — Load `specs/{feature}/spec.md` to extract user stories (US1, US2, etc.) and acceptance criteria.
+
+3. **Create a Feature Issue** — One parent issue that describes the feature as a whole. Label it `feature`.
+
+4. **Create Story Issues** — One issue per user story from the spec. Label them `story`. Reference the Feature issue.
+
+5. **Create Task Issues** — One issue per task from tasks.md. Label them `task` and apply priority labels. Reference the parent Story issue.
+
+6. **Report** — Output a summary table of all created issues with their numbers and URLs.
+
+## Issue Templates
+
+### Feature Issue
+```
+Title: [FEATURE] {Feature name from spec}
+
+## Description
+{One paragraph from spec.md overview section}
+
+## Acceptance Criteria
+{From spec.md acceptance criteria section}
+
+## User Stories
+{List of US1, US2, etc. with brief descriptions}
+
+## Implementation Plan
+Spec: specs/{feature}/spec.md
+Plan: specs/{feature}/plan.md
+Tasks: specs/{feature}/tasks.md
+```
+
+### Story Issue  
+```
+Title: [STORY] US{N}: {User story title}
+
+## User Story
+{As a [persona], I want [action], so that [benefit]}
+
+## Acceptance Criteria
+{AC items from spec for this story}
+
+Parent: #{Feature issue number}
+```
+
+### Task Issue
+```
+Title: [TASK] T{NNN}: {Task description}
+
+## Task
+{Task description from tasks.md}
+
+Priority: {P1-Critical|P2-High|P3-Medium} 
+Story: #{Story issue number}
+File: {file path from task}
+```
+
+## Labels to Create (if missing)
+
+Run `gh label create` for any of these that don't exist:
+- `feature` (color: #0075ca)
+- `story` (color: #e4e669)  
+- `task` (color: #cfd3d7)
+- `priority:critical` (color: #d73a4a)
+- `priority:high` (color: #e99695)
+- `priority:medium` (color: #f9d0c4)
+
+## After Creating Issues
+
+Output a summary:
+```
+Created {N} issues:
+  Feature: #{N} - {title} 
+  Stories: #{N}, #{N}, ...
+  Tasks:   #{N} through #{N}
+
+Sprint planning URL: {repo}/projects
+```

--- a/examples/prompts/create-technical-spike.prompt.md
+++ b/examples/prompts/create-technical-spike.prompt.md
@@ -1,0 +1,86 @@
+---
+agent: agent
+description: Create a time-boxed technical spike document. Use this before speccing a feature when there is genuine technical uncertainty — unknown unknowns that would cause the spec to be inaccurate.
+---
+
+# Create Technical Spike Document
+
+You are a senior engineer facilitating a technical investigation. Help the user define and document a time-boxed spike to resolve technical uncertainty before writing a feature specification.
+
+## When to Use a Spike
+
+A spike is appropriate when:
+- The team doesn't know enough to estimate a story
+- An approach needs proof-of-concept before committing to it  
+- Integration with an external system is unproven
+- Performance or scalability claims need validation
+- A technology choice is undecided
+
+**A spike is not appropriate when** the uncertainty can be resolved by reading documentation or asking a colleague. If it can be answered in 15 minutes, just answer it.
+
+## Process
+
+1. **Define the uncertainty** — What exactly is unknown? What would make this spike successful?
+2. **Set the timebox** — Spikes must be time-boxed. Suggest 1, 2, or 4 hours based on scope.
+3. **Define output** — What artifact will exist at the end? (code proof-of-concept, decision, benchmark result, recommendation)
+4. **Create the spike document** — Save to `specs/spikes/SPIKE-{NNN}-{slug}.md`
+
+## Spike Document Template
+
+```markdown
+# SPIKE-{NNN}: {Short Title}
+
+**Date:** {YYYY-MM-DD}  
+**Timebox:** {X hours}  
+**Owner:** {Name or team}  
+**Status:** Open | In Progress | Complete | Abandoned  
+
+---
+
+## Question to Answer
+
+{State the single question this spike must answer. If you have more than one question, split into multiple spikes.}
+
+## Background
+
+{Why is this uncertain? What do we already know? What have we already tried?}
+
+## Approach
+
+{How will we investigate? What will we build, read, benchmark, or prototype?}
+
+**Out of scope for this spike:**
+- {Explicitly state what we are NOT answering}
+
+## Timebox Budget
+
+| Activity | Time |
+|---|---|
+| Setup / reading | {X min} |
+| Prototype / experiment | {X min} |
+| Write-up / decision | {X min} |
+| **Total** | **{X hrs}** |
+
+## Success Criteria
+
+- [ ] {Measurable criterion 1}
+- [ ] {Measurable criterion 2}
+
+## Results
+
+{Filled in after the spike. What did we find?}
+
+## Decision / Recommendation
+
+{Based on the findings, what should we do? Reference any ADR that results from this spike.}
+
+## Artifacts
+
+- {Link to prototype code, benchmark results, POC repo, etc.}
+```
+
+## Guidelines
+
+- If the spike runs over time, stop and document what you found so far — don't let it expand
+- The spike output must result in a clear decision, not just more questions
+- After completing a spike, update the related spec in `specs/` to reflect the findings

--- a/examples/prompts/refactor-plan.prompt.md
+++ b/examples/prompts/refactor-plan.prompt.md
@@ -1,0 +1,66 @@
+---
+agent: 'agent'
+tools: ['search/codebase']
+description: 'Plan a multi-file refactor with proper sequencing and rollback steps'
+---
+
+# Refactor Plan
+
+Create a detailed plan for this refactoring task.
+
+## Refactor Goal
+
+{{refactor_description}}
+
+## Instructions
+
+1. Search the codebase to understand current state
+2. Identify all affected files and their dependencies
+3. Plan changes in a safe sequence (types first, then implementations, then tests)
+4. Include verification steps between changes
+5. Consider rollback if something fails
+
+## Output Format
+
+```markdown
+## Refactor Plan: [title]
+
+### Current State
+[Brief description of how things work now]
+
+### Target State
+[Brief description of how things will work after]
+
+### Affected Files
+| File | Change Type | Dependencies |
+|------|-------------|--------------|
+| path | modify/create/delete | blocks X, blocked by Y |
+
+### Execution Plan
+
+#### Phase 1: Types and Interfaces
+- [ ] Step 1.1: [action] in `file.ts`
+- [ ] Verify: [how to check it worked]
+
+#### Phase 2: Implementation
+- [ ] Step 2.1: [action] in `file.ts`
+- [ ] Verify: [how to check]
+
+#### Phase 3: Tests
+- [ ] Step 3.1: Update tests in `file.test.ts`
+- [ ] Verify: Run `npm test`
+
+#### Phase 4: Cleanup
+- [ ] Remove deprecated code
+- [ ] Update documentation
+
+### Rollback Plan
+If something fails:
+1. [Step to undo]
+2. [Step to undo]
+
+### Risks
+- [Potential issue and mitigation]
+```
+
+Shall I proceed with Phase 1?

--- a/examples/prompts/what-context-needed.prompt.md
+++ b/examples/prompts/what-context-needed.prompt.md
@@ -1,0 +1,40 @@
+---
+agent: 'agent'
+tools: ['search/codebase']
+description: 'Ask Copilot what files it needs to see before answering a question'
+---
+
+# What Context Do You Need?
+
+Before answering my question, tell me what files you need to see.
+
+## My Question
+
+{{question}}
+
+## Instructions
+
+1. Based on my question, list the files you would need to examine
+2. Explain why each file is relevant
+3. Note any files you've already seen in this conversation
+4. Identify what you're uncertain about
+
+## Output Format
+
+```markdown
+## Files I Need
+
+### Must See (required for accurate answer)
+- `path/to/file.ts` — [why needed]
+
+### Should See (helpful for complete answer)
+- `path/to/file.ts` — [why helpful]
+
+### Already Have
+- `path/to/file.ts` — [from earlier in conversation]
+
+### Uncertainties
+- [What I'm not sure about without seeing the code]
+```
+
+After I provide these files, I'll ask my question again.


### PR DESCRIPTION
## SpecDD Starter Kit

This PR adds the EY ATTG SDLC Starter Kit to **Modern To Do - Task Time Added**.

> **Note:** 90 files already existed in this repo and were not overwritten.

### 18 new files added

**Other** — 18 files
- `docs/faq.md`
- `docs/greenfield-vs-brownfield.md`
- `docs/references.md`
- `docs/sdd-methodology.md`
- `docs/starter-guide.md`
- `docs/workflow.md`
- `examples/README.md`
- `examples/instructions/agent-safety.instructions.md`
- _…and 10 more_

---
*Generated by the EY ATTG SDLC Wizard.*